### PR TITLE
Removes Duplicate APCs on Holestation

### DIFF
--- a/_maps/map_files/HoleStation/holestation.dmm
+++ b/_maps/map_files/HoleStation/holestation.dmm
@@ -844,14 +844,6 @@
 	},
 /turf/open/floor/plasteel/dark/airless,
 /area/tcommsat/server/upper)
-"aee" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar/atrium)
 "aeh" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor/heavy,
@@ -2965,7 +2957,6 @@
 /area/ai_monitored/turret_protected/ai)
 "anT" = (
 /obj/machinery/door/airlock/public/glass,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
@@ -3529,8 +3520,6 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/assistant,
-/obj/machinery/power/apc/auto_name/south,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -6208,7 +6197,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aDI" = (
@@ -13935,7 +13923,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "jqB" = (
@@ -16127,14 +16114,12 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/west,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 5
 	},
-/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "pQy" = (
@@ -18518,7 +18503,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "wtJ" = (
@@ -46797,8 +46781,8 @@ ahS
 aiU
 akZ
 fEi
-aee
-aee
+qbc
+qbc
 aqo
 ask
 ask
@@ -47054,7 +47038,7 @@ aGt
 omQ
 kdx
 jiF
-aee
+qbc
 qbc
 qbc
 aCv
@@ -47311,7 +47295,7 @@ wnF
 iSt
 gKk
 fvt
-aee
+qbc
 kFu
 asN
 des


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
kills two duplicate APCs I didn't notice because I couldn't compile.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: A few duplicate APCs on Holestation have been killed off.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
