### PR TITLE
[PORT] Shuttle Ceilings

### DIFF
--- a/_maps/holestation.json
+++ b/_maps/holestation.json
@@ -8,7 +8,7 @@
 		"whiteship": "whiteship_box",
 		"emergency": "emergency_holestation"
 	},
-	"traits": [{"Up" : 1, "Linkage" : "Cross"}, {"Down" : -1, "Baseturf" : "/turf/open/openspace", "Linkage" : "Cross"}],
+	"traits": [{"Up" : 1, "Linkage" : "Cross"}, {"Down" : -1, "Baseturf" : "/turf/open/transparent/openspace", "Linkage" : "Cross"}],
 	"job_changes": {
 		"Lawyer": {
 			"total_positions": 0,

--- a/code/game/turfs/open/floor/hull.dm
+++ b/code/game/turfs/open/floor/hull.dm
@@ -12,6 +12,15 @@
 		return FALSE
 	return ..()
 
+/// RCD-immune plating generated only by shuttle code for shuttle ceilings on multi-z maps, should not be mapped in or creatable in any other way
+/turf/open/floor/engine/hull/ceiling
+	name = "shuttle ceiling plating"
+	var/old_turf_type
+
+/turf/open/floor/engine/hull/ceiling/AfterChange(flags, oldType)
+	. = ..()
+	old_turf_type = oldType
+
 /turf/open/floor/engine/hull/reinforced
 	name = "exterior reinforced hull plating"
 	desc = "Extremely sturdy exterior hull plating that separates you from the uncaring vacuum of space."

--- a/code/modules/shuttle/docking.dm
+++ b/code/modules/shuttle/docking.dm
@@ -168,9 +168,19 @@
 		CHECK_TICK
 		if(!(old_turfs[old_turfs[i]] & MOVE_TURF))
 			continue
-		var/turf/oldT = old_turfs[i]
-		var/turf/newT = new_turfs[i]
-		newT.afterShuttleMove(oldT, rotation)																//turfs
+		var/turf/old_turf = old_turfs[i]
+		var/turf/new_turf = new_turfs[i]
+		new_turf.afterShuttleMove(old_turf, rotation) //turfs
+		var/turf/new_ceiling = get_step_multiz(new_turf, UP) // check if a ceiling is needed
+		if(new_ceiling)
+			// generate ceiling
+			if(istype(new_ceiling, /turf/open/transparent/openspace))
+				new_ceiling.ChangeTurf(/turf/open/floor/engine/hull/ceiling, list(/turf/open/transparent/openspace))
+		var/turf/old_ceiling = get_step_multiz(old_turf, UP)
+		if(old_ceiling && istype(old_ceiling, /turf/open/floor/engine/hull/ceiling)) // check if a ceiling was generated previously
+			// remove old ceiling
+			var/turf/open/floor/engine/hull/ceiling/old_shuttle_ceiling = old_ceiling
+			old_shuttle_ceiling.ChangeTurf(/turf/baseturf_bottom)															//turfs
 
 	for(var/i in 1 to moved_atoms.len)
 		CHECK_TICK


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ports https://github.com/Monkestation/MonkeStation/pull/353 and, in turn, https://github.com/tgstation/tgstation/pull/64493.

Adds ceilings to shuttles on Multi-Z maps, to prevent atmos from flowing out on tile updates and cheese with the move up / move down verbs. Additionally fixes an issue where Holestation had an improper baseturf.
![image](https://user-images.githubusercontent.com/50649185/207697885-969a1f37-a4a0-4ff1-9d07-2c7c76305010.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Allows for shuttles to safely be used on the bottom floor of Multi-Z maps.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: RandomGamer123, Iamgoofball, IssacTheSharkWolf, unit0016
add: Nanotrasen has finally discovered what a "ceiling" is and have implemented this revolutionary design to improve safety onboard shuttlecraft.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
