### PR TITLE
Holey-Moley: Every Job Is Now On Holestation. Every Head Now Has An Office.

### DIFF
--- a/_maps/holestation.json
+++ b/_maps/holestation.json
@@ -8,15 +8,5 @@
 		"whiteship": "whiteship_box",
 		"emergency": "emergency_holestation"
 	},
-	"traits": [{"Up" : 1, "Linkage" : "Cross"}, {"Down" : -1, "Baseturf" : "/turf/open/transparent/openspace", "Linkage" : "Cross"}],
-	"job_changes": {
-		"Lawyer": {
-			"total_positions": 0,
-			"spawn_positions": 0
-		},
-		"Psychologist": {
-			"total_positions": 0,
-			"spawn_positions": 0
-		}
-	}
+	"traits": [{"Up" : 1, "Linkage" : "Cross"}, {"Down" : -1, "Baseturf" : "/turf/open/transparent/openspace", "Linkage" : "Cross"}]
 }

--- a/_maps/map_files/HoleStation/holestation.dmm
+++ b/_maps/map_files/HoleStation/holestation.dmm
@@ -105,11 +105,16 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hop)
 "aat" = (
-/obj/structure/chair/plastic,
-/obj/effect/decal/cleanable/shreds,
-/obj/effect/landmark/start/research_director,
-/turf/open/floor/eighties,
-/area/maintenance/fore)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/half{
+	dir = 4
+	},
+/area/ai_monitored/turret_protected/ai_upload_foyer)
 "aau" = (
 /turf/closed/wall,
 /area/crew_quarters/heads/hop)
@@ -311,7 +316,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/crew_quarters/heads/hor)
 "abr" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -580,11 +585,14 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "acF" = (
 /turf/open/floor/plasteel,
-/area/maintenance/fore)
+/area/crew_quarters/heads/hor)
 "acI" = (
 /obj/structure/closet/secure_closet/engineering_chief,
 /obj/structure/extinguisher_cabinet{
@@ -904,8 +912,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "aev" = (
-/turf/open/floor/plasteel/dark,
-/area/maintenance/fore)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hor)
 "aew" = (
 /obj/structure/ladder,
 /obj/effect/turf_decal/stripes/line,
@@ -1318,8 +1327,8 @@
 /turf/open/floor/engine/n2o,
 /area/engine/atmos)
 "agJ" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/fore)
+/turf/closed/wall/r_wall/rust,
+/area/crew_quarters/heads/hor)
 "agL" = (
 /obj/structure/window,
 /obj/structure/window/spawner/east,
@@ -3211,7 +3220,7 @@
 	dir = 1
 	},
 /turf/open/floor/eighties,
-/area/maintenance/fore)
+/area/crew_quarters/heads/hor)
 "aoS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -3883,6 +3892,13 @@
 	pixel_x = -5
 	},
 /obj/item/hand_tele,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 9
+	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "arZ" = (
@@ -5385,7 +5401,7 @@
 /area/space/nearstation)
 "azj" = (
 /turf/open/floor/eighties,
-/area/maintenance/fore)
+/area/crew_quarters/heads/hor)
 "azk" = (
 /obj/structure/table/wood/fancy,
 /obj/item/flashlight/lantern,
@@ -5883,9 +5899,12 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hos)
 "aBC" = (
-/obj/machinery/computer/arcade/orion_trail,
-/turf/open/floor/eighties,
-/area/maintenance/fore)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
+/turf/open/floor/plasteel/dark/half{
+	dir = 4
+	},
+/area/crew_quarters/heads/hor)
 "aBF" = (
 /obj/machinery/vending/autodrobe,
 /obj/machinery/camera/autoname{
@@ -7280,11 +7299,13 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen/coldroom)
 "aHY" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark/half{
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/area/maintenance/fore)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/xmastree/rdrod,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hor)
 "aHZ" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/chem_master,
@@ -7717,9 +7738,10 @@
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "aJT" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/bar/diagonal,
+/obj/effect/spawner/xmastree,
 /turf/open/floor/plasteel/dark,
-/area/maintenance/fore)
+/area/crew_quarters/bar/atrium)
 "aJU" = (
 /obj/structure/bookcase/random/reference,
 /turf/open/floor/wood,
@@ -8078,7 +8100,7 @@
 "aLN" = (
 /mob/living/simple_animal/bot/floorbot,
 /turf/open/floor/plasteel,
-/area/maintenance/fore)
+/area/crew_quarters/heads/hor)
 "aLO" = (
 /obj/effect/turf_decal/bot_red,
 /obj/vehicle/ridden/secway,
@@ -8902,12 +8924,9 @@
 /turf/open/floor/plating,
 /area/science/lab)
 "aPs" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/machinery/airalarm/directional/north,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
-/area/maintenance/fore)
+/area/crew_quarters/heads/hor)
 "aPt" = (
 /turf/open/transparent/openspace,
 /area/science/research)
@@ -9568,8 +9587,14 @@
 /turf/open/floor/plasteel/mil,
 /area/quartermaster/miningdock)
 "aRQ" = (
-/turf/closed/wall,
-/area/maintenance/fore)
+/obj/structure/chair/plastic,
+/obj/effect/decal/cleanable/shreds,
+/obj/effect/landmark/start/research_director,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/eighties,
+/area/crew_quarters/heads/hor)
 "aRR" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/item/paper/guides/jobs/hydroponics,
@@ -9805,6 +9830,7 @@
 /obj/structure/table,
 /obj/item/paper_bin,
 /obj/item/pen,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "aSO" = (
@@ -10380,6 +10406,9 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
@@ -11346,11 +11375,13 @@
 /turf/closed/wall,
 /area/quartermaster/storage)
 "bbb" = (
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "bbs" = (
@@ -11814,10 +11845,13 @@
 /turf/open/floor/plasteel/dark/edge,
 /area/crew_quarters/dorms)
 "cya" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 8
-	},
 /obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
@@ -12105,14 +12139,6 @@
 /obj/structure/closet/crate/internals,
 /turf/open/floor/plasteel/mil/cargo,
 /area/quartermaster/warehouse)
-"drt" = (
-/obj/effect/decal/cleanable/plasma,
-/obj/item/picket_sign{
-	name = "kid's corner sign";
-	desc = "It reads, \"Ages 8 and under!\" - There's a incredibly, incredibly disgusting pizza stain across the cartoon mascot."
-	},
-/turf/open/floor/eighties,
-/area/maintenance/fore)
 "dtM" = (
 /obj/effect/decal/cleanable/greenglow,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -12555,11 +12581,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"eGH" = (
-/obj/effect/turf_decal/tile/bar/diagonal,
-/obj/effect/spawner/xmastree,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar/atrium)
 "eHp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -12723,6 +12744,9 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"fhH" = (
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hor)
 "fhZ" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/neutral,
@@ -12786,16 +12810,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
-"fqk" = (
-/obj/structure/sign/plaques/kiddie{
-	pixel_y = 32
-	},
-/obj/structure/closet/secure_closet/research_director,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/fore)
 "fvt" = (
 /obj/effect/landmark/start/assistant,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
@@ -13409,6 +13423,14 @@
 	dir = 8
 	},
 /area/ai_monitored/turret_protected/ai_upload_foyer)
+"gFP" = (
+/obj/effect/decal/cleanable/plasma,
+/obj/item/picket_sign{
+	name = "kid's corner sign";
+	desc = "It reads, \"Ages 8 and under!\" - There's a incredibly, incredibly disgusting pizza stain across the cartoon mascot."
+	},
+/turf/open/floor/eighties,
+/area/crew_quarters/heads/hor)
 "gIn" = (
 /obj/structure/lattice/catwalk,
 /turf/open/transparent/openspace,
@@ -13452,6 +13474,17 @@
 /obj/structure/cable,
 /turf/open/transparent/openspace,
 /area/maintenance/central/secondary)
+"gLg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -28
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/plasteel/dark/half{
+	dir = 4
+	},
+/area/crew_quarters/heads/hor)
 "gLH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
 /obj/effect/turf_decal/tile/red/diagonal,
@@ -13535,6 +13568,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/lab)
+"heL" = (
+/turf/closed/wall/r_wall/rust,
+/area/ai_monitored/turret_protected/ai_upload_foyer)
 "hfg" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L7"
@@ -13764,7 +13800,7 @@
 /obj/structure/girder,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
-/area/maintenance/fore)
+/area/crew_quarters/heads/hor)
 "hSv" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -13867,6 +13903,9 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/nuke_storage)
+"iiI" = (
+/turf/closed/wall/r_wall/rust,
+/area/ai_monitored/turret_protected/ai_upload)
 "ikg" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
 	dir = 1
@@ -14322,14 +14361,6 @@
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/lab)
-"jmE" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/xmastree/rdrod,
-/turf/open/floor/plasteel/dark,
-/area/maintenance/fore)
 "jnO" = (
 /obj/effect/landmark/start/assistant,
 /obj/effect/turf_decal/siding/wood{
@@ -14338,14 +14369,17 @@
 /turf/open/floor/carpet,
 /area/library/lounge)
 "jow" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 4
-	},
 /obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
@@ -14639,7 +14673,7 @@
 "jPF" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
-/area/maintenance/fore)
+/area/crew_quarters/heads/hor)
 "jPQ" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
@@ -14675,6 +14709,19 @@
 /obj/effect/spawner/structure/window/hollow/middle,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"jWJ" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/airlock/command/glass{
+	name = "Research Director";
+	req_access_txt = "30"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark/half{
+	dir = 4
+	},
+/area/ai_monitored/turret_protected/ai_upload_foyer)
 "jXd" = (
 /obj/effect/landmark/start/cyborg,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
@@ -15185,16 +15232,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft/secondary)
-"lmB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel/dark/half{
-	dir = 4
-	},
-/area/maintenance/fore)
 "lno" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 10
@@ -15396,14 +15433,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"mbp" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/half{
-	dir = 4
-	},
-/area/ai_monitored/turret_protected/ai_upload_foyer)
 "mct" = (
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
@@ -15718,6 +15747,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"ndc" = (
+/obj/machinery/suit_storage_unit/rd,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/hor)
 "neN" = (
 /obj/structure/table,
 /obj/item/storage/box/beakers{
@@ -16092,7 +16129,7 @@
 "ofw" = (
 /obj/structure/girder/displaced,
 /turf/open/floor/plasteel,
-/area/maintenance/fore)
+/area/crew_quarters/heads/hor)
 "ogk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
@@ -16197,14 +16234,6 @@
 /obj/structure/window/reinforced/spawner/east,
 /turf/open/floor/plating,
 /area/medical)
-"olz" = (
-/obj/machinery/modular_computer/console/preset/research{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/small,
-/turf/open/floor/eighties,
-/area/maintenance/fore)
 "omG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -16231,8 +16260,11 @@
 "ooA" = (
 /obj/effect/decal/cleanable/plastic,
 /obj/item/pizzabox/meat,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 8
+	},
 /turf/open/floor/eighties,
-/area/maintenance/fore)
+/area/crew_quarters/heads/hor)
 "opI" = (
 /obj/effect/landmark/start/medical_doctor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -16591,6 +16623,16 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
 /turf/open/floor/wood,
 /area/library/lounge)
+"pgK" = (
+/obj/structure/sign/plaques/kiddie{
+	pixel_y = 32
+	},
+/obj/structure/closet/secure_closet/research_director,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/hor)
 "phI" = (
 /obj/structure/window/reinforced/survival_pod{
 	dir = 8
@@ -16940,6 +16982,18 @@
 "qrB" = (
 /turf/closed/wall,
 /area/lawoffice)
+"quc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 6
+	},
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark/half{
+	dir = 4
+	},
+/area/crew_quarters/heads/hor)
 "qvG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -16992,6 +17046,9 @@
 /obj/item/shard,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"qEs" = (
+/turf/closed/wall/r_wall/rust,
+/area/ai_monitored/turret_protected/ai)
 "qEv" = (
 /obj/structure/table/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
@@ -17385,13 +17442,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "rIp" = (
-/obj/machinery/suit_storage_unit/rd,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/maintenance/fore)
+/turf/closed/wall/r_wall,
+/area/crew_quarters/heads/hor)
 "rIr" = (
 /obj/structure/cable,
 /obj/item/reagent_containers/food/snacks/cracker,
@@ -17673,6 +17725,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark/side{
 	dir = 4
 	},
@@ -17810,9 +17865,16 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "sEl" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/obj/machinery/modular_computer/console/preset/research{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/eighties,
+/area/crew_quarters/heads/hor)
 "sEm" = (
 /obj/structure/cable,
 /turf/open/floor/engine/hull,
@@ -18089,11 +18151,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "trI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "tse" = (
@@ -18611,16 +18673,15 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"uzJ" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/door/airlock/command/glass{
-	name = "Research Director";
-	req_access_txt = "30"
+"uAv" = (
+/obj/structure/chair/office{
+	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel/dark/half{
 	dir = 4
 	},
-/area/maintenance/fore)
+/area/ai_monitored/turret_protected/ai_upload_foyer)
 "uGl" = (
 /obj/structure/railing{
 	dir = 1
@@ -19012,7 +19073,7 @@
 	},
 /obj/effect/decal/cleanable/vomit,
 /turf/open/floor/eighties,
-/area/maintenance/fore)
+/area/crew_quarters/heads/hor)
 "vMI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/door/airlock/public/glass{
@@ -19819,9 +19880,13 @@
 "xyg" = (
 /turf/closed/wall,
 /area/tcommsat/server/upper)
+"xyS" = (
+/obj/machinery/computer/arcade/orion_trail,
+/turf/open/floor/eighties,
+/area/crew_quarters/heads/hor)
 "xAv" = (
-/turf/closed/wall/r_wall/rust,
-/area/maintenance/fore)
+/turf/closed/wall,
+/area/crew_quarters/heads/hor)
 "xAM" = (
 /obj/structure/table/wood,
 /obj/item/toy/figure/syndie{
@@ -20031,6 +20096,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"xUe" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hor)
 "xUo" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 8
@@ -47739,7 +47811,7 @@ aiU
 akZ
 fEi
 tPr
-eGH
+aJT
 aqo
 ask
 ask
@@ -118154,9 +118226,9 @@ gSA
 aMw
 aMw
 aOt
-agJ
-agJ
-agJ
+axx
+axx
+aVE
 ahm
 aVE
 aVE
@@ -118410,15 +118482,15 @@ exy
 aKY
 phI
 phI
-xAv
-xAv
-rIp
-xAv
-agJ
-agJ
+qEs
+qEs
+ndc
+iiI
+aVE
+aVE
 aqW
-aqW
-mbp
+aat
+uAv
 alb
 eLx
 aaZ
@@ -118667,12 +118739,12 @@ awm
 anb
 xvT
 xvT
-xAv
-fqk
-aHY
-lmB
-aHY
-uzJ
+qEs
+pgK
+aBC
+gLg
+quc
+jWJ
 acD
 arY
 aSN
@@ -118924,13 +118996,13 @@ ueb
 aGR
 omG
 xvT
-agJ
-jmE
-aev
-drt
-olz
-xAv
-agJ
+axx
+aHY
+fhH
+gFP
+sEl
+heL
+aJr
 aJr
 aJr
 aJr
@@ -119179,15 +119251,15 @@ ckA
 axx
 axx
 anJ
-agJ
-xAv
-agJ
+axx
+qEs
+axx
+xUe
 aPs
-aJT
 azj
-aat
+aRQ
 aoR
-sEl
+aev
 lFz
 lFz
 lFz
@@ -119434,17 +119506,17 @@ ckA
 ckA
 ckA
 eLx
-agJ
-xAv
-agJ
+axx
+qEs
+axx
 jPF
 hPK
 ofw
-aJT
-aBC
+aPs
+xyS
 ooA
 vMl
-sEl
+aev
 lFz
 lFz
 lFz
@@ -119691,17 +119763,17 @@ ckA
 ckA
 ckA
 eLx
-agJ
+rIp
 abq
-aRQ
+xAv
 acF
 aLN
 jPF
 acF
+rIp
 agJ
-xAv
+rIp
 agJ
-xAv
 lFz
 lFz
 lFz
@@ -119948,14 +120020,14 @@ ckA
 ckA
 ckA
 ckA
+rIp
 agJ
-xAv
+rIp
 agJ
-xAv
 jPF
+rIp
+rIp
 agJ
-agJ
-xAv
 lFz
 eLx
 aLs
@@ -120208,9 +120280,9 @@ ckA
 eLx
 lFz
 lFz
-sEl
+aev
 jPF
-sEl
+aev
 eLx
 lFz
 lFz
@@ -120465,9 +120537,9 @@ ckA
 eLx
 aFs
 aFs
-agJ
-aRQ
-agJ
+rIp
+xAv
+rIp
 aFs
 lFz
 lFz

--- a/_maps/map_files/HoleStation/holestation.dmm
+++ b/_maps/map_files/HoleStation/holestation.dmm
@@ -1412,8 +1412,9 @@
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "ahb" = (
-/obj/structure/railing,
-/obj/effect/turf_decal/siding/green,
+/obj/effect/turf_decal/siding/green/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel/mil,
 /area/quartermaster/warehouse)
 "ahd" = (
@@ -3265,12 +3266,15 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "apa" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/obj/structure/railing,
+/obj/effect/turf_decal/siding/green,
+/turf/open/floor/plasteel/mil,
+/area/quartermaster/warehouse)
 "apb" = (
-/turf/closed/wall,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "apc" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3889,11 +3893,10 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "arZ" = (
-/obj/effect/turf_decal/siding/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel/mil/box,
-/area/quartermaster/warehouse)
+/obj/structure/grille,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "asa" = (
 /obj/structure/sign/painting/library{
 	pixel_y = -32
@@ -3944,12 +3947,8 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "asm" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
+/turf/closed/wall/r_wall,
+/area/quartermaster/warehouse)
 "aso" = (
 /obj/structure/table,
 /turf/open/floor/plasteel,
@@ -4560,11 +4559,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical)
+/turf/open/floor/carpet/blue,
+/area/medical/psychology)
 "avm" = (
 /obj/machinery/door/airlock/grunge{
 	id_tag = "Cabin_1";
@@ -5268,7 +5264,7 @@
 /area/hydroponics)
 "ayy" = (
 /turf/closed/wall,
-/area/medical)
+/area/medical/psychology)
 "ayA" = (
 /obj/machinery/door/window/westleft,
 /obj/machinery/door/window/eastleft,
@@ -6272,10 +6268,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aDw" = (
-/obj/machinery/power/apc/auto_name/west,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
+/obj/machinery/vending/wardrobe/law_wardrobe,
+/turf/open/floor/wood,
+/area/lawoffice)
 "aDz" = (
 /obj/machinery/shower{
 	dir = 8;
@@ -6989,24 +6984,9 @@
 /turf/open/floor/plasteel,
 /area/science/lab)
 "aGE" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/structure/sign/directions/medical{
-	pixel_y = -40;
-	dir = 4
-	},
-/obj/structure/sign/directions/science{
-	pixel_y = -22
-	},
-/obj/structure/sign/directions/security{
-	pixel_y = -28
-	},
-/obj/structure/sign/directions/supply{
-	pixel_y = -34
-	},
+/obj/structure/chair,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hydroponics)
 "aGF" = (
 /obj/structure/railing{
 	dir = 1
@@ -7558,9 +7538,10 @@
 /turf/open/floor/plasteel,
 /area/science/lab)
 "aJd" = (
-/obj/structure/closet/toolcloset,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
+/obj/structure/rack,
+/obj/item/storage/briefcase,
+/turf/open/floor/wood,
+/area/lawoffice)
 "aJe" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -7585,12 +7566,9 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "aJj" = (
-/obj/structure/chair,
-/obj/item/clothing/head/hardhat{
-	pixel_y = -4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/central)
+/obj/structure/filingcabinet/employment,
+/turf/open/floor/wood,
+/area/lawoffice)
 "aJk" = (
 /obj/machinery/computer/station_alert{
 	dir = 4
@@ -7872,9 +7850,14 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "aKB" = (
-/obj/item/stack/cable_coil,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/lawoffice)
 "aKE" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/syringes{
@@ -7891,9 +7874,12 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "aKF" = (
-/obj/item/wirecutters,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/landmark/start/lawyer,
+/turf/open/floor/wood,
+/area/lawoffice)
 "aKJ" = (
 /obj/structure/lattice,
 /obj/structure/grille,
@@ -7911,8 +7897,14 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/prison)
 "aKM" = (
-/turf/open/floor/plating,
-/area/maintenance/port/central)
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/carpet/blue,
+/area/lawoffice)
 "aKN" = (
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/plating,
@@ -7950,11 +7942,6 @@
 /obj/effect/turf_decal/bot_red,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"aKQ" = (
-/obj/effect/spawner/structure/window/hollow/middle,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "aKR" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/turf_decal/stripes/line{
@@ -8357,14 +8344,13 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "aMU" = (
-/obj/machinery/door/airlock/external/glass{
-	req_access_txt = "13"
+/obj/structure/table/wood,
+/obj/item/book/manual/wiki/security_space_law{
+	pixel_y = 5
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/central)
+/obj/item/cartridge/lawyer,
+/turf/open/floor/carpet/blue,
+/area/lawoffice)
 "aMX" = (
 /obj/docking_port/stationary{
 	dwidth = 4;
@@ -8562,9 +8548,13 @@
 /turf/open/floor/wood,
 /area/chapel/main)
 "aNW" = (
-/obj/structure/girder,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel/anticorner{
+	dir = 8
+	},
+/area/quartermaster/qm)
 "aNX" = (
 /obj/structure/reagent_dispensers/cooking_oil,
 /obj/effect/turf_decal/delivery,
@@ -10212,17 +10202,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/nuke_storage)
-"aUI" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
-	dir = 8
-	},
-/turf/open/transparent/openspace,
-/area/maintenance/central)
 "aUL" = (
 /obj/effect/landmark/start/depsec/science,
 /obj/effect/turf_decal/stripes{
@@ -10993,12 +10972,12 @@
 /turf/open/floor/plasteel,
 /area/engine/supermatter)
 "aYo" = (
-/obj/machinery/computer/cargo{
+/obj/machinery/computer/security/qm{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow/whole,
 /obj/effect/turf_decal/siding/yellow{
-	dir = 10
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark/whole,
 /area/quartermaster/qm)
@@ -11444,22 +11423,10 @@
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bhM" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 1
-	},
-/turf/open/floor/plasteel/anticorner{
-	dir = 8
-	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/west,
+/turf/open/floor/plasteel,
 /area/quartermaster/qm)
-"bin" = (
-/obj/structure/safe/floor,
-/obj/item/clothing/under/syndicate,
-/obj/item/clothing/under/syndicate/skirt,
-/obj/item/clothing/head/hos/beret/syndicate,
-/obj/item/clothing/gloves/combat,
-/obj/item/clothing/shoes/combat,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "biw" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table,
@@ -11726,12 +11693,11 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/item/radio/intercom{
-	dir = 8;
-	pixel_x = 28
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/structure/cable,
+/obj/structure/sign/departments/lawyer{
+	pixel_x = 32
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bQV" = (
@@ -11756,6 +11722,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/science/lab)
+"bWv" = (
+/obj/effect/turf_decal/siding/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mil/box,
+/area/quartermaster/warehouse)
 "bWZ" = (
 /obj/machinery/camera/autoname{
 	dir = 10
@@ -11828,14 +11800,8 @@
 /area/hydroponics)
 "csR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
-/turf/open/floor/plasteel/white,
-/area/medical)
-"cuG" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
+/turf/open/floor/wood,
+/area/medical/psychology)
 "cvf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -11899,6 +11865,11 @@
 	dir = 1
 	},
 /area/security/brig)
+"cFM" = (
+/turf/open/floor/plasteel/anticorner{
+	dir = 1
+	},
+/area/quartermaster/qm)
 "cGb" = (
 /obj/machinery/turretid{
 	pixel_y = 24
@@ -11915,6 +11886,25 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"cIi" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/sign/directions/medical{
+	pixel_y = -40;
+	dir = 4
+	},
+/obj/structure/sign/directions/science{
+	pixel_y = -22
+	},
+/obj/structure/sign/directions/security{
+	pixel_y = -28
+	},
+/obj/structure/sign/directions/supply{
+	pixel_y = -34
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "cIn" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -12027,9 +12017,11 @@
 /area/maintenance/starboard/aft/secondary)
 "deh" = (
 /obj/machinery/airalarm/directional/south,
-/obj/structure/table/optable,
-/turf/open/floor/plasteel/dark,
-/area/medical)
+/obj/structure/chair/sofa/right{
+	dir = 1
+	},
+/turf/open/floor/carpet/blue,
+/area/medical/psychology)
 "des" = (
 /obj/effect/landmark/start/assistant,
 /obj/machinery/firealarm{
@@ -12089,22 +12081,16 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"dkT" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "dlW" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/machinery/vending/wardrobe/hydro_wardrobe,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "dmN" = (
-/obj/machinery/stasis,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical)
+/obj/structure/closet/secure_closet/psychology,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/plasteel/dark,
+/area/medical/psychology)
 "dni" = (
 /obj/structure/cable,
 /obj/structure/lattice/catwalk,
@@ -12186,6 +12172,10 @@
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"dCr" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/plasteel/mil/cargo,
+/area/quartermaster/warehouse)
 "dDS" = (
 /obj/structure/railing{
 	dir = 4
@@ -12269,16 +12259,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engine/engine_smes)
-"dQs" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "dTx" = (
 /obj/machinery/light{
 	dir = 1
@@ -12367,6 +12347,13 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/mil,
 /area/quartermaster/miningdock)
+"ebN" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/qm)
 "ecX" = (
 /obj/effect/decal/cleanable/greenglow,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -12390,6 +12377,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"efd" = (
+/turf/closed/wall/r_wall,
+/area/quartermaster/qm)
 "efS" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass,
@@ -12407,6 +12397,9 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/grass,
 /area/science/genetics)
+"egH" = (
+/turf/closed/wall,
+/area/quartermaster/qm)
 "egS" = (
 /turf/closed/wall/r_wall,
 /area/janitor)
@@ -12432,6 +12425,15 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hop)
+"eor" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin/bundlenatural,
+/obj/item/pen,
+/obj/item/stamp/qm,
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/quartermaster/qm)
 "epL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -12484,6 +12486,17 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/library)
+"ewx" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/turf/open/transparent/openspace,
+/area/maintenance/central)
 "ewV" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
 /obj/effect/turf_decal/tile/neutral,
@@ -12566,6 +12579,33 @@
 "eLx" = (
 /turf/open/floor/engine/hull/reinforced,
 /area/space/nearstation)
+"eLy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/structure/sign/directions/command{
+	pixel_y = 42;
+	dir = 1
+	},
+/obj/structure/sign/directions/dorms{
+	pixel_y = 36;
+	dir = 4
+	},
+/obj/structure/sign/directions/engineering{
+	pixel_y = 30;
+	dir = 4
+	},
+/obj/structure/sign/directions/evac{
+	pixel_y = 24;
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "eMy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
@@ -12612,6 +12652,10 @@
 /obj/structure/cable,
 /turf/open/floor/mineral/plastitanium/airless,
 /area/space/nearstation)
+"eSO" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/lawoffice)
 "eVN" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -12711,33 +12755,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"fiO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/structure/sign/directions/command{
-	pixel_y = 42;
-	dir = 1
-	},
-/obj/structure/sign/directions/dorms{
-	pixel_y = 36;
-	dir = 4
-	},
-/obj/structure/sign/directions/engineering{
-	pixel_y = 30;
-	dir = 4
-	},
-/obj/structure/sign/directions/evac{
-	pixel_y = 24;
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "fki" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/structure/window/reinforced,
@@ -12832,8 +12849,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"fzz" = (
-/obj/structure/girder,
+"fxV" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "fzA" = (
@@ -13203,6 +13226,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"ghW" = (
+/obj/effect/spawner/structure/window/hollow/directional,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "gjE" = (
 /obj/effect/landmark/start/shaft_miner,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
@@ -13466,11 +13494,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/toilet)
-"gUx" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
 "gUO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -13540,6 +13563,16 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/main)
+"hlt" = (
+/obj/structure/closet/firecloset/full,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/sign/departments/mait{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "hmp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 9
@@ -13639,6 +13672,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"hHi" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/north,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "hHr" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
 	dir = 8
@@ -13940,6 +13978,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"iwH" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/qm)
 "iwU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
@@ -14091,10 +14135,6 @@
 "iRn" = (
 /turf/open/floor/plasteel/mil,
 /area/quartermaster/warehouse)
-"iSc" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "iSi" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/transparent/glass,
@@ -14331,6 +14371,17 @@
 	},
 /turf/open/floor/plating,
 /area/chapel/main)
+"jqT" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "jrI" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/firealarm{
@@ -14430,11 +14481,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 5
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical)
+/turf/open/floor/wood,
+/area/medical/psychology)
 "jAv" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -14442,6 +14490,10 @@
 /obj/structure/cable,
 /turf/open/floor/mineral/plastitanium/airless,
 /area/maintenance/central/secondary)
+"jBl" = (
+/obj/machinery/photocopier,
+/turf/open/floor/carpet/blue,
+/area/lawoffice)
 "jCI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
@@ -14468,10 +14520,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
-"jFd" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
-/turf/open/floor/plasteel/mil/cargo,
-/area/quartermaster/warehouse)
 "jFA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 5
@@ -14533,9 +14581,9 @@
 	},
 /area/hallway/secondary/exit)
 "jKv" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/mil,
+/area/quartermaster/warehouse)
 "jKY" = (
 /obj/machinery/vending/snack/random,
 /obj/machinery/light{
@@ -14543,14 +14591,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
-"jLQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
-/obj/structure/cable,
-/turf/open/floor/plasteel/mil/cargo/arrow,
-/area/quartermaster/warehouse)
 "jMz" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Quartermaster";
@@ -14587,12 +14627,6 @@
 /obj/structure/cable,
 /turf/open/transparent/openspace,
 /area/maintenance/central)
-"jOb" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
 "jPF" = (
 /obj/item/clothing/head/fedora,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -14644,6 +14678,11 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/ai_upload)
+"jXg" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "jXV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/effect/turf_decal/tile/neutral{
@@ -14687,6 +14726,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/computer/warrant{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -14734,19 +14776,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/mil,
 /area/quartermaster/storage)
-"kkj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/brown/half/contrast{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
 "kmc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
@@ -14856,17 +14885,10 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"kyY" = (
-/turf/open/floor/plasteel/anticorner{
-	dir = 1
-	},
-/area/quartermaster/qm)
-"kCy" = (
-/obj/structure/sign/departments/mait{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
+"kEr" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "kEw" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -14945,6 +14967,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"kLW" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "kOD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
@@ -15030,9 +15057,8 @@
 /turf/open/floor/plating,
 /area/security/nuke_storage)
 "kYZ" = (
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/white,
-/area/medical)
+/turf/open/floor/wood,
+/area/medical/psychology)
 "kZN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
@@ -15179,12 +15205,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"lst" = (
-/obj/structure/closet/crate{
-	name = "spare parts"
-	},
-/turf/open/floor/plasteel/mil/cargo,
-/area/quartermaster/warehouse)
 "lsS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
@@ -15248,7 +15268,9 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "lFn" = (
-/obj/machinery/airalarm/directional/north,
+/obj/structure/closet/crate{
+	name = "spare parts"
+	},
 /turf/open/floor/plasteel/mil/cargo,
 /area/quartermaster/warehouse)
 "lFz" = (
@@ -15294,25 +15316,6 @@
 /obj/effect/spawner/structure/window/hollow/end,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"lKY" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/structure/sign/directions/command{
-	pixel_y = -22;
-	dir = 8
-	},
-/obj/structure/sign/directions/dorms{
-	pixel_y = -28
-	},
-/obj/structure/sign/directions/engineering{
-	pixel_y = -34
-	},
-/obj/structure/sign/directions/evac{
-	pixel_y = -40
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "lQf" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -15366,11 +15369,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/mil,
 /area/quartermaster/miningdock)
-"lWM" = (
-/obj/structure/cable,
-/obj/structure/window,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "lYl" = (
 /obj/machinery/light{
 	dir = 8
@@ -15424,6 +15422,12 @@
 /obj/item/stack/tile/plasteel,
 /turf/open/space/basic,
 /area/maintenance/port/aft)
+"mjo" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/lawoffice)
 "mml" = (
 /obj/effect/turf_decal/tile/brown/diagonal,
 /turf/open/floor/plasteel/dark,
@@ -15518,8 +15522,10 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
-/area/medical)
+/obj/structure/table/wood,
+/obj/machinery/computer/med_data/laptop,
+/turf/open/floor/wood,
+/area/medical/psychology)
 "mBW" = (
 /obj/effect/turf_decal/bot_red,
 /obj/effect/landmark/start/roboticist,
@@ -15528,6 +15534,19 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/science/research)
+"mCk" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "mCu" = (
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/plasteel/white,
@@ -15627,6 +15646,14 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"mYG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
+/obj/structure/cable,
+/turf/open/floor/plasteel/mil/cargo/arrow,
+/area/quartermaster/warehouse)
 "mYW" = (
 /obj/item/toy/cattoy,
 /obj/structure/bed/dogbed,
@@ -15699,16 +15726,6 @@
 "nfK" = (
 /turf/closed/wall/r_wall,
 /area/medical/sleeper)
-"nfZ" = (
-/obj/structure/closet/firecloset/full,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/sign/departments/mait{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "ngo" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -15847,13 +15864,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyer";
-	name = "Auxillary Exam Room";
-	req_access_txt = "5"
+/obj/machinery/door/airlock/medical{
+	name = "Psychology";
+	req_access_txt = "70"
 	},
-/turf/open/floor/plasteel/white,
-/area/medical)
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/medical/psychology)
 "nHG" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
@@ -15864,11 +15884,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
-"nIA" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/north,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "nIK" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -15916,10 +15931,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"nNE" = (
-/obj/structure/chair,
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "nOC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/box,
@@ -15955,6 +15966,15 @@
 /obj/machinery/atmospherics/pipe/multiz,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft/secondary)
+"nUD" = (
+/obj/structure/safe/floor,
+/obj/item/clothing/under/syndicate,
+/obj/item/clothing/under/syndicate/skirt,
+/obj/item/clothing/head/hos/beret/syndicate,
+/obj/item/clothing/gloves/combat,
+/obj/item/clothing/shoes/combat,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "nUV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -16015,6 +16035,11 @@
 /obj/machinery/atmospherics/pipe/multiz,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"obj" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "ocp" = (
 /obj/machinery/computer/operating{
 	dir = 8
@@ -16233,11 +16258,23 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"oBj" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/central)
+"oAR" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/effect/landmark/start/lawyer,
+/turf/open/floor/carpet/blue,
+/area/lawoffice)
+"oBe" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen,
+/obj/item/taperecorder,
+/turf/open/floor/carpet/blue,
+/area/lawoffice)
 "oBG" = (
 /obj/structure/railing,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
@@ -16602,11 +16639,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"pwl" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/west,
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
 "pxp" = (
 /obj/item/radio/intercom{
 	pixel_y = 22
@@ -16709,17 +16741,11 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"pRP" = (
-/obj/structure/lattice/catwalk,
+"pTg" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 4
-	},
-/turf/open/transparent/openspace,
-/area/maintenance/central)
+/obj/effect/spawner/structure/window/hollow,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "pUO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
@@ -16801,15 +16827,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
-"qgN" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin/bundlenatural,
-/obj/item/pen,
-/obj/item/stamp/qm,
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
-/area/quartermaster/qm)
 "qgQ" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/effect/turf_decal/stripes/line{
@@ -16892,14 +16909,8 @@
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "qrB" = (
-/obj/machinery/door/airlock/external/glass{
-	req_access_txt = "13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/central)
+/turf/closed/wall,
+/area/lawoffice)
 "qvG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -17129,6 +17140,9 @@
 /obj/structure/cable,
 /turf/open/floor/mineral/plastitanium/airless,
 /area/space/nearstation)
+"rdH" = (
+/turf/open/floor/plasteel/dark,
+/area/quartermaster/qm)
 "reu" = (
 /obj/structure/cable,
 /turf/open/floor/plasteel/mil,
@@ -17140,6 +17154,19 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen/coldroom)
+"rll" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/cable,
+/obj/item/radio/intercom{
+	dir = 8;
+	pixel_x = 28
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "rlq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 4
@@ -17193,12 +17220,10 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "rro" = (
-/obj/structure/closet/crate/freezer/surplus_limbs,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical)
+/obj/structure/filingcabinet/medical,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/plasteel/dark,
+/area/medical/psychology)
 "rrQ" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
@@ -17325,16 +17350,11 @@
 /obj/effect/landmark/start/chemist,
 /turf/open/floor/plasteel/white,
 /area/medical/office)
-"rFD" = (
-/obj/machinery/computer/security/qm{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow/whole,
-/obj/effect/turf_decal/siding/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/whole,
-/area/quartermaster/qm)
+"rHJ" = (
+/obj/structure/cable,
+/obj/structure/window,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "rIp" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external/glass{
@@ -17430,7 +17450,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/structure/table,
+/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "rTO" = (
@@ -17555,17 +17575,6 @@
 	},
 /turf/open/floor/plasteel/mil,
 /area/crew_quarters/bar/atrium)
-"sdy" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance/three,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "sdW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/camera/autoname{
@@ -17648,12 +17657,8 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "squ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/plasteel/dark,
-/area/medical)
+/turf/open/floor/carpet/blue,
+/area/medical/psychology)
 "sqS" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
 	dir = 8
@@ -17768,21 +17773,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft/secondary)
-"sBE" = (
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/mil,
-/area/quartermaster/warehouse)
-"sBJ" = (
-/obj/structure/grille,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
-"sDk" = (
-/obj/effect/turf_decal/siding/green/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/mil,
-/area/quartermaster/warehouse)
 "sDI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -17844,6 +17834,22 @@
 /obj/structure/cable,
 /turf/open/transparent/openspace,
 /area/maintenance/central/secondary)
+"sQZ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/door/airlock{
+	name = "Law Office";
+	req_access_txt = "38"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/lawoffice)
 "sTg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 9
@@ -18107,11 +18113,6 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"txG" = (
-/obj/effect/spawner/structure/window/hollow/directional,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "txM" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -18135,11 +18136,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "tzs" = (
-/obj/machinery/computer/operating{
+/obj/structure/chair/sofa/left{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/medical)
+/turf/open/floor/carpet/blue,
+/area/medical/psychology)
 "tzP" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -18201,12 +18202,12 @@
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "tFc" = (
-/obj/machinery/smartfridge/organ,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/chair/comfy/brown{
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/medical)
+/obj/effect/landmark/start/psychologist,
+/turf/open/floor/carpet/blue,
+/area/medical/psychology)
 "tGz" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_access_txt = "41"
@@ -18284,8 +18285,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/medical)
+"tNz" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
+/turf/open/floor/plasteel/mil/cargo,
+/area/quartermaster/warehouse)
 "tNI" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -18302,6 +18308,11 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"tOU" = (
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "tPj" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -18427,6 +18438,17 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/qm)
+"ujT" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/quartermaster/qm)
+"ulS" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "una" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass,
@@ -18500,11 +18522,6 @@
 /obj/structure/cable,
 /turf/open/transparent/openspace,
 /area/maintenance/central/secondary)
-"uvE" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance/two,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "uwi" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
@@ -18618,6 +18635,17 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
 /turf/open/floor/wood,
 /area/library)
+"uOT" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 8
+	},
+/turf/open/transparent/openspace,
+/area/maintenance/central)
 "uPe" = (
 /turf/closed/wall,
 /area/science/genetics)
@@ -18685,6 +18713,10 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/hallway/primary/central)
+"vcc" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "vcv" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L13"
@@ -18775,19 +18807,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"vqD" = (
-/turf/closed/wall/r_wall,
-/area/quartermaster/warehouse)
-"vsv" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "vsI" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
@@ -18825,6 +18844,16 @@
 /obj/item/stock_parts/cell/high,
 /turf/open/floor/plasteel/mil,
 /area/quartermaster/storage)
+"vxg" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/table,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "vxH" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -18903,8 +18932,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 6
 	},
-/turf/open/floor/plasteel/white,
-/area/medical)
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/north,
+/turf/open/floor/wood,
+/area/medical/psychology)
 "vFn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
@@ -19053,6 +19084,25 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"vZO" = (
+/obj/structure/sign/departments/mait{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
+"wae" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/brown/half/contrast{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/qm)
 "wbb" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
 	dir = 4
@@ -19114,9 +19164,9 @@
 /turf/open/floor/plasteel/dark/side,
 /area/ai_monitored/security/armory)
 "weO" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
-/area/medical)
+/area/medical/psychology)
 "wfs" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/toxin{
@@ -19201,12 +19251,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"wlX" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
-/area/quartermaster/qm)
 "wlZ" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/engine/o2,
@@ -19253,18 +19297,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
-"wsj" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
 "wsR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
@@ -19338,6 +19370,11 @@
 /obj/structure/chair/stool,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"wCQ" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/plasteel,
+/area/quartermaster/qm)
 "wEa" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
@@ -19465,6 +19502,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/hallway/primary/central)
+"wWm" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	pixel_y = 14;
+	pixel_x = -5
+	},
+/obj/item/folder/blue,
+/obj/item/pen/red,
+/obj/item/stamp/law,
+/turf/open/floor/carpet/blue,
+/area/lawoffice)
 "wWu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -19508,6 +19556,16 @@
 	dir = 1
 	},
 /area/medical/virology)
+"wZy" = (
+/obj/machinery/computer/cargo{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow/whole,
+/obj/effect/turf_decal/siding/yellow{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark/whole,
+/area/quartermaster/qm)
 "wZN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -19605,35 +19663,21 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/theatre)
 "xmo" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/quartermaster/qm)
-"xmv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/structure/sign/directions/medical{
-	pixel_y = 42;
 	dir = 1
 	},
-/obj/structure/sign/directions/science{
-	pixel_y = 36;
+/obj/structure/sign/directions/command{
+	pixel_y = -22;
 	dir = 8
 	},
-/obj/structure/sign/directions/security{
-	pixel_y = 30;
-	dir = 8
+/obj/structure/sign/directions/dorms{
+	pixel_y = -28
 	},
-/obj/structure/sign/directions/supply{
-	pixel_y = 24;
-	dir = 8
+/obj/structure/sign/directions/engineering{
+	pixel_y = -34
+	},
+/obj/structure/sign/directions/evac{
+	pixel_y = -40
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -19702,6 +19746,10 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/transparent/openspace,
 /area/maintenance/port/aft)
+"xsq" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "xsr" = (
 /obj/machinery/rnd/production/techfab/department/medical,
 /obj/structure/sign/departments/examroom{
@@ -19761,11 +19809,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
-"xDK" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/hollow,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "xEO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
@@ -19841,7 +19884,8 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "xIJ" = (
-/turf/closed/wall/r_wall,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/quartermaster/qm)
 "xJn" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
@@ -19888,6 +19932,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"xMb" = (
+/obj/effect/spawner/structure/window/hollow/middle,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "xMD" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -19970,6 +20019,35 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"ycr" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/sign/directions/medical{
+	pixel_y = 42;
+	dir = 1
+	},
+/obj/structure/sign/directions/science{
+	pixel_y = 36;
+	dir = 8
+	},
+/obj/structure/sign/directions/security{
+	pixel_y = 30;
+	dir = 8
+	},
+/obj/structure/sign/directions/supply{
+	pixel_y = 24;
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "ycA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -19978,11 +20056,6 @@
 /obj/structure/cable/layer3,
 /turf/open/floor/plating,
 /area/engine/engine_room)
-"yek" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "yfj" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -19994,8 +20067,17 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"yfH" = (
-/turf/open/floor/plasteel/dark,
+"yij" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "yjt" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
@@ -47644,7 +47726,7 @@ aQc
 abV
 rNA
 aCb
-nfZ
+hlt
 azO
 azO
 aPc
@@ -48917,9 +48999,9 @@ yfj
 dhm
 wbb
 axz
-axz
+mCk
 bOA
-axz
+rll
 tLX
 axz
 sXf
@@ -49173,18 +49255,18 @@ aoU
 axK
 aGA
 axK
-axK
-axK
-axK
-axK
-axK
+eSO
+sQZ
+qrB
+qrB
+acj
 acj
 azq
 azq
 azq
 acj
 acj
-fiO
+eLy
 mUy
 aSr
 aAq
@@ -49429,17 +49511,17 @@ aCG
 aCG
 axK
 aGK
-jKv
+axK
 aDw
 aKB
 aKM
-aKM
-axK
+jBl
+acj
 aQx
 iRn
 iRn
 iRn
-sBE
+jKv
 acj
 gvS
 ahK
@@ -49675,9 +49757,9 @@ aMj
 ajF
 aln
 aPZ
-aGE
+cIi
 aoU
-nNE
+aGE
 sdf
 cIp
 tHV
@@ -49686,12 +49768,12 @@ kuE
 tJP
 aEZ
 aGN
-aNW
+axK
 aJd
 aKF
-axK
+wWm
 aMU
-axK
+acj
 aQz
 aGy
 sjs
@@ -49942,13 +50024,13 @@ ayx
 aAa
 arh
 axK
-aKM
+tOU
 axK
 aJj
-aKM
-axK
-aKM
-axK
+mjo
+oAR
+oBe
+acj
 auh
 ayt
 fKe
@@ -50201,11 +50283,11 @@ awu
 axK
 aHa
 axK
-aHa
-aHa
-axK
 qrB
-axK
+qrB
+qrB
+qrB
+acj
 acj
 acj
 xEO
@@ -53787,7 +53869,7 @@ aam
 akC
 kRJ
 aPZ
-lKY
+xmo
 apy
 aYt
 qbM
@@ -54324,7 +54406,7 @@ aUe
 aUe
 aOz
 aOz
-xmv
+ycr
 aCj
 aHA
 avr
@@ -56391,7 +56473,7 @@ aiL
 aJy
 aIk
 aCk
-kCy
+vZO
 aJB
 aSz
 aWN
@@ -113958,7 +114040,7 @@ nYC
 wRn
 alj
 azO
-yek
+kLW
 pek
 iSi
 azO
@@ -114202,7 +114284,7 @@ rOK
 rOK
 rOK
 rOK
-aUI
+uOT
 bqt
 rOK
 pmf
@@ -114459,7 +114541,7 @@ akS
 akS
 akS
 akS
-pRP
+ewx
 akS
 akS
 aJl
@@ -114970,9 +115052,9 @@ lFz
 lFz
 lFz
 lFz
-vqD
+asm
+dCr
 lFn
-lst
 rCu
 gAQ
 xQI
@@ -115227,11 +115309,11 @@ lFz
 lFz
 eLx
 eLx
-vqD
+asm
 iRn
 iRn
 fKe
-ahb
+apa
 xQI
 aZt
 tSm
@@ -115484,12 +115566,12 @@ lFz
 lFz
 eLx
 lFz
-vqD
+asm
 dri
-jFd
-jLQ
-sDk
-arZ
+tNz
+mYG
+ahb
+bWv
 aZt
 tSm
 akS
@@ -115741,7 +115823,7 @@ eLx
 eLx
 eLx
 aLs
-vqD
+asm
 aLD
 acj
 jMz
@@ -115998,13 +116080,13 @@ ckA
 ckA
 ckA
 ckA
-xIJ
-asm
-gUx
-kkj
-pwl
-cuG
+efd
+ebN
+wCQ
+wae
+bhM
 apb
+egH
 tSm
 akS
 aSE
@@ -116255,13 +116337,13 @@ ckA
 ckA
 ckA
 ckA
-xmo
-jOb
-kyY
-wsj
-bhM
-cuG
-xmo
+xIJ
+iwH
+cFM
+yij
+aNW
+apb
+xIJ
 tSm
 akS
 aSE
@@ -116512,13 +116594,13 @@ ckA
 ckA
 ckA
 ckA
-xmo
+xIJ
 vey
-qgN
+eor
 ciY
-wlX
+ujT
 vey
-xmo
+xIJ
 tSm
 akS
 aSE
@@ -116769,13 +116851,13 @@ ckA
 ckA
 ckA
 ckA
-xmo
+xIJ
 mml
 ueU
 oFy
 mml
 mml
-xmo
+xIJ
 tSm
 akS
 akS
@@ -117026,13 +117108,13 @@ ckA
 ckA
 ckA
 ckA
-xIJ
-rFD
+efd
 aYo
-yfH
+wZy
+rdH
 hvQ
 oDa
-apb
+egH
 tSm
 hSv
 hSv
@@ -117541,10 +117623,10 @@ ckA
 ckA
 ckA
 aFz
-bin
-aKQ
+nUD
+xMb
 aww
-dkT
+kEr
 afh
 wTs
 tSm
@@ -117798,10 +117880,10 @@ ckA
 ckA
 ckA
 aFz
-sBJ
-txG
+arZ
+ghW
 aww
-uvE
+ulS
 afh
 qhU
 tSm
@@ -118055,10 +118137,10 @@ ckA
 ckA
 ckA
 aFz
-apa
-lWM
+obj
+rHJ
 aww
-fzz
+vcc
 afh
 qhU
 tSm
@@ -118313,11 +118395,11 @@ ckA
 ckA
 aFz
 aww
-xDK
+pTg
 aGf
-iSc
+xsq
 acV
-oBj
+jXg
 tSm
 aKZ
 avw
@@ -118569,8 +118651,8 @@ ckA
 ckA
 ckA
 aFz
-nIA
-iSc
+hHi
+xsq
 aww
 aww
 afh
@@ -118826,10 +118908,10 @@ ckA
 ckA
 ckA
 aFz
-dQs
-vsv
-sdy
+fxV
 rSO
+jqT
+vxg
 afh
 afh
 juU

--- a/_maps/map_files/HoleStation/holestation.dmm
+++ b/_maps/map_files/HoleStation/holestation.dmm
@@ -105,11 +105,11 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hop)
 "aat" = (
-/obj/structure/chair/office,
-/turf/open/floor/plasteel/dark/half{
-	dir = 4
-	},
-/area/ai_monitored/turret_protected/ai_upload_foyer)
+/obj/structure/chair/plastic,
+/obj/effect/decal/cleanable/shreds,
+/obj/effect/landmark/start/research_director,
+/turf/open/floor/eighties,
+/area/maintenance/fore)
 "aau" = (
 /turf/closed/wall,
 /area/crew_quarters/heads/hop)
@@ -306,6 +306,10 @@
 /turf/open/floor/plating,
 /area/engine/engine_smes)
 "abq" = (
+/obj/machinery/computer/arcade/amputation{
+	desc = "Is this what was responsible for the amputation of 2487?";
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "abr" = (
@@ -340,13 +344,9 @@
 /turf/open/floor/plating,
 /area/engine/engine_smes)
 "aby" = (
-/obj/machinery/suit_storage_unit/rd,
-/obj/structure/window/reinforced/spawner/east,
-/obj/structure/window/reinforced/spawner/north,
-/obj/machinery/door/window/brigdoor/westright{
-	req_access_txt = "30"
+/turf/open/floor/plasteel/anticorner{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/science/lab)
 "abz" = (
 /obj/machinery/vending/wardrobe/science_wardrobe,
@@ -580,15 +580,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "acF" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/maintenance/fore)
 "acI" = (
 /obj/structure/closet/secure_closet/engineering_chief,
@@ -909,14 +904,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "aev" = (
-/obj/machinery/door/airlock/external/glass{
-	req_access_txt = "13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/maintenance/fore)
 "aew" = (
 /obj/structure/ladder,
@@ -3219,8 +3207,10 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "aoR" = (
-/obj/structure/closet/emcloset/anchored,
-/turf/open/floor/plating,
+/obj/machinery/computer/robotics{
+	dir = 1
+	},
+/turf/open/floor/eighties,
 /area/maintenance/fore)
 "aoS" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -3884,12 +3874,15 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/computer/station_alert{
-	dir = 8
-	},
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/table,
+/obj/item/flashlight/lamp/green{
+	pixel_y = 13;
+	pixel_x = -5
+	},
+/obj/item/hand_tele,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "arZ" = (
@@ -5046,8 +5039,9 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai)
 "axy" = (
-/obj/item/book/codex_gigas,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/cult/tome,
+/obj/item/book/codex_gigas,
 /turf/open/floor/plasteel/cult,
 /area/library)
 "axz" = (
@@ -5390,12 +5384,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "azj" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/machinery/light,
-/turf/open/transparent/openspace,
+/turf/open/floor/eighties,
 /area/maintenance/fore)
 "azk" = (
 /obj/structure/table/wood/fancy,
@@ -5894,11 +5883,9 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hos)
 "aBC" = (
-/obj/effect/turf_decal/trimline/yellow/corner{
-	dir = 1
-	},
-/turf/open/floor/engine/hull,
-/area/space/nearstation)
+/obj/machinery/computer/arcade/orion_trail,
+/turf/open/floor/eighties,
+/area/maintenance/fore)
 "aBF" = (
 /obj/machinery/vending/autodrobe,
 /obj/machinery/camera/autoname{
@@ -7293,7 +7280,10 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen/coldroom)
 "aHY" = (
-/turf/open/transparent/openspace,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark/half{
+	dir = 4
+	},
 /area/maintenance/fore)
 "aHZ" = (
 /obj/machinery/door/firedoor/heavy,
@@ -7727,16 +7717,9 @@
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "aJT" = (
-/obj/structure/table,
-/obj/item/flashlight/lamp/green{
-	pixel_y = 13;
-	pixel_x = -5
-	},
-/obj/item/hand_tele,
-/turf/open/floor/plasteel/dark/half{
-	dir = 4
-	},
-/area/ai_monitored/turret_protected/ai_upload_foyer)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/maintenance/fore)
 "aJU" = (
 /obj/structure/bookcase/random/reference,
 /turf/open/floor/wood,
@@ -8093,8 +8076,8 @@
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "aLN" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
+/mob/living/simple_animal/bot/floorbot,
+/turf/open/floor/plasteel,
 /area/maintenance/fore)
 "aLO" = (
 /obj/effect/turf_decal/bot_red,
@@ -8110,13 +8093,8 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "aLQ" = (
-/obj/structure/window/reinforced/spawner/east,
-/obj/structure/closet/secure_closet/research_director,
-/obj/structure/window/reinforced,
-/obj/machinery/door/window/brigdoor/westleft{
-	req_access_txt = "30"
-	},
-/turf/open/floor/plasteel,
+/obj/effect/landmark/start/scientist,
+/turf/open/floor/plasteel/anticorner,
 /area/science/lab)
 "aLR" = (
 /obj/machinery/atmospherics/components/unary/passive_vent{
@@ -8924,11 +8902,11 @@
 /turf/open/floor/plating,
 /area/science/lab)
 "aPs" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing{
-	dir = 8
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
-/turf/open/transparent/openspace,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/plasteel/dark,
 /area/maintenance/fore)
 "aPt" = (
 /turf/open/transparent/openspace,
@@ -9186,7 +9164,6 @@
 /area/engine/atmos)
 "aQs" = (
 /obj/machinery/airalarm/directional/east,
-/obj/effect/landmark/start/scientist,
 /turf/open/floor/plasteel,
 /area/science/lab)
 "aQt" = (
@@ -9822,12 +9799,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/computer/monitor{
-	dir = 8
-	},
 /obj/machinery/camera/autoname{
 	dir = 9
 	},
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "aSO" = (
@@ -12128,6 +12105,14 @@
 /obj/structure/closet/crate/internals,
 /turf/open/floor/plasteel/mil/cargo,
 /area/quartermaster/warehouse)
+"drt" = (
+/obj/effect/decal/cleanable/plasma,
+/obj/item/picket_sign{
+	name = "kid's corner sign";
+	desc = "It reads, \"Ages 8 and under!\" - There's a incredibly, incredibly disgusting pizza stain across the cartoon mascot."
+	},
+/turf/open/floor/eighties,
+/area/maintenance/fore)
 "dtM" = (
 /obj/effect/decal/cleanable/greenglow,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -12570,6 +12555,11 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"eGH" = (
+/obj/effect/turf_decal/tile/bar/diagonal,
+/obj/effect/spawner/xmastree,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar/atrium)
 "eHp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -12796,6 +12786,16 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
+"fqk" = (
+/obj/structure/sign/plaques/kiddie{
+	pixel_y = 32
+	},
+/obj/structure/closet/secure_closet/research_director,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/fore)
 "fvt" = (
 /obj/effect/landmark/start/assistant,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
@@ -13761,9 +13761,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "hPK" = (
-/obj/machinery/power/apc/auto_name/west,
-/obj/structure/cable,
-/turf/open/floor/plating,
+/obj/structure/girder,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
 /area/maintenance/fore)
 "hSv" = (
 /obj/structure/lattice/catwalk,
@@ -14319,8 +14319,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
+/obj/effect/landmark/start/scientist,
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/lab)
+"jmE" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/xmastree/rdrod,
+/turf/open/floor/plasteel/dark,
+/area/maintenance/fore)
 "jnO" = (
 /obj/effect/landmark/start/assistant,
 /obj/effect/turf_decal/siding/wood{
@@ -14628,9 +14637,8 @@
 /turf/open/transparent/openspace,
 /area/maintenance/central)
 "jPF" = (
-/obj/item/clothing/head/fedora,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
 /area/maintenance/fore)
 "jPQ" = (
 /obj/structure/lattice/catwalk,
@@ -15148,7 +15156,6 @@
 /area/hallway/primary/central)
 "lku" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
-/obj/effect/landmark/start/research_director,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
 	dir = 1
 	},
@@ -15178,6 +15185,16 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft/secondary)
+"lmB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel/dark/half{
+	dir = 4
+	},
+/area/maintenance/fore)
 "lno" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 10
@@ -15379,6 +15396,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"mbp" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/half{
+	dir = 4
+	},
+/area/ai_monitored/turret_protected/ai_upload_foyer)
 "mct" = (
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
@@ -16065,9 +16090,8 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ofw" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/turf/open/transparent/openspace,
+/obj/structure/girder/displaced,
+/turf/open/floor/plasteel,
 /area/maintenance/fore)
 "ogk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
@@ -16173,6 +16197,14 @@
 /obj/structure/window/reinforced/spawner/east,
 /turf/open/floor/plating,
 /area/medical)
+"olz" = (
+/obj/machinery/modular_computer/console/preset/research{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small,
+/turf/open/floor/eighties,
+/area/maintenance/fore)
 "omG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -16197,12 +16229,9 @@
 /turf/open/floor/wood,
 /area/library/lounge)
 "ooA" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/structure/cable,
-/obj/machinery/door/airlock/external/glass{
-	req_access_txt = "13"
-	},
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/plastic,
+/obj/item/pizzabox/meat,
+/turf/open/floor/eighties,
 /area/maintenance/fore)
 "opI" = (
 /obj/effect/landmark/start/medical_doctor,
@@ -17356,11 +17385,12 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "rIp" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/external/glass{
-	req_access_txt = "13"
+/obj/machinery/suit_storage_unit/rd,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
 /area/maintenance/fore)
 "rIr" = (
 /obj/structure/cable,
@@ -18581,6 +18611,16 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"uzJ" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/airlock/command/glass{
+	name = "Research Director";
+	req_access_txt = "30"
+	},
+/turf/open/floor/plasteel/dark/half{
+	dir = 4
+	},
+/area/maintenance/fore)
 "uGl" = (
 /obj/structure/railing{
 	dir = 1
@@ -18967,8 +19007,11 @@
 /turf/open/floor/plasteel,
 /area/engine/storage)
 "vMl" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
+/obj/machinery/computer/mecha{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/vomit,
+/turf/open/floor/eighties,
 /area/maintenance/fore)
 "vMI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -19777,13 +19820,7 @@
 /turf/closed/wall,
 /area/tcommsat/server/upper)
 "xAv" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/door/airlock/external/glass{
-	req_access_txt = "13"
-	},
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall/rust,
 /area/maintenance/fore)
 "xAM" = (
 /obj/structure/table/wood,
@@ -47702,7 +47739,7 @@ aiU
 akZ
 fEi
 tPr
-tPr
+eGH
 aqo
 ask
 ask
@@ -118373,15 +118410,15 @@ exy
 aKY
 phI
 phI
+xAv
+xAv
+rIp
+xAv
 agJ
 agJ
-aHY
-agJ
-agJ
-agJ
-aJT
-aat
 aqW
+aqW
+mbp
 alb
 eLx
 aaZ
@@ -118630,12 +118667,12 @@ awm
 anb
 xvT
 xvT
-agJ
+xAv
+fqk
 aHY
+lmB
 aHY
-aHY
-aHY
-agJ
+uzJ
 acD
 arY
 aSN
@@ -118888,17 +118925,17 @@ aGR
 omG
 xvT
 agJ
-aHY
-aHY
-aHY
-agJ
-agJ
+jmE
+aev
+drt
+olz
+xAv
 agJ
 aJr
 aJr
 aJr
 eLx
-ayN
+aaZ
 pmM
 aLs
 eLx
@@ -119143,19 +119180,19 @@ axx
 axx
 anJ
 agJ
-agJ
+xAv
 agJ
 aPs
-aPs
+aJT
 azj
-aRQ
+aat
 aoR
-agJ
-eQp
-sEm
-sEm
-bym
-sEm
+sEl
+lFz
+lFz
+lFz
+eLx
+aaZ
 pmM
 eLx
 lFz
@@ -119398,19 +119435,19 @@ ckA
 ckA
 eLx
 agJ
-agJ
+xAv
 agJ
 jPF
 hPK
 ofw
-ofw
-ofw
+aJT
+aBC
 ooA
 vMl
-aev
-tAX
-alD
-aaL
+sEl
+lFz
+lFz
+lFz
 eLx
 aiP
 oEs
@@ -119654,19 +119691,19 @@ ckA
 ckA
 ckA
 eLx
-rIp
+agJ
 abq
-xAv
-abq
+aRQ
+acF
 aLN
-aLN
+jPF
 acF
 agJ
+xAv
 agJ
-agJ
-agJ
-adx
-aBC
+xAv
+lFz
+lFz
 lFz
 eLx
 ajR
@@ -119912,13 +119949,13 @@ ckA
 ckA
 ckA
 agJ
+xAv
+agJ
+xAv
+jPF
 agJ
 agJ
-agJ
-abq
-agJ
-agJ
-agJ
+xAv
 lFz
 eLx
 aLs
@@ -120172,7 +120209,7 @@ eLx
 lFz
 lFz
 sEl
-aLN
+jPF
 sEl
 eLx
 lFz

--- a/_maps/map_files/HoleStation/holestation.dmm
+++ b/_maps/map_files/HoleStation/holestation.dmm
@@ -790,13 +790,12 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "adI" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_access_txt = "12"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance_hatch{
+	req_access_txt = "31"
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "adK" = (
@@ -1402,13 +1401,9 @@
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "ahb" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
+/obj/structure/railing,
 /turf/open/floor/plasteel/mil,
-/area/quartermaster/storage)
+/area/maintenance/department/cargo)
 "ahd" = (
 /obj/effect/turf_decal/tile/blue/diagonal,
 /turf/open/floor/plasteel,
@@ -3888,8 +3883,12 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "arZ" = (
-/obj/structure/closet/crate/medical,
-/turf/open/floor/plasteel/mil/cargo,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -28
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/mil,
 /area/quartermaster/warehouse)
 "asa" = (
 /obj/structure/sign/painting/library{
@@ -4165,8 +4164,7 @@
 /area/maintenance/central/secondary)
 "atu" = (
 /obj/machinery/computer/piratepad_control/civilian,
-/obj/structure/window/reinforced/spawner/north,
-/turf/open/floor/plasteel/mil,
+/turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "atw" = (
 /turf/open/floor/plasteel/dark/side{
@@ -4329,10 +4327,11 @@
 /area/hydroponics)
 "auh" = (
 /obj/structure/closet/crate/engineering,
-/obj/item/stack/sheet/glass/fifty,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 28
 	},
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/plasteel/mil/cargo,
 /area/quartermaster/warehouse)
 "aui" = (
@@ -6960,9 +6959,10 @@
 /turf/open/floor/plasteel,
 /area/science/lab)
 "aGE" = (
-/obj/effect/landmark/start/cargo_technician,
-/turf/open/floor/plasteel/mil,
-/area/quartermaster/storage)
+/obj/structure/closet/crate/medical,
+/obj/structure/railing/corner,
+/turf/open/floor/plasteel/mil/cargo,
+/area/quartermaster/warehouse)
 "aGF" = (
 /obj/structure/railing{
 	dir = 1
@@ -7570,10 +7570,11 @@
 "aJp" = (
 /obj/structure/table,
 /obj/item/stack/sheet/glass/fifty,
-/obj/item/clothing/glasses/welding,
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/clothing/glasses/welding,
 /turf/open/floor/plasteel,
 /area/science/lab)
 "aJq" = (
@@ -8040,8 +8041,7 @@
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/cmo)
 "aLD" = (
-/obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable,
+/obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aLH" = (
@@ -8750,6 +8750,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/obj/effect/landmark/start/cargo_technician,
 /turf/open/floor/plasteel/mil,
 /area/quartermaster/storage)
 "aOL" = (
@@ -10497,6 +10498,9 @@
 /obj/machinery/newscaster{
 	pixel_x = -32
 	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/science/research)
 "aWr" = (
@@ -10926,13 +10930,9 @@
 /turf/open/floor/plasteel,
 /area/engine/supermatter)
 "aYo" = (
-/obj/structure/closet/crate/internals,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel/mil/cargo,
-/area/quartermaster/warehouse)
+/obj/structure/closet/secure_closet/quartermaster,
+/turf/open/floor/plasteel,
+/area/maintenance/department/cargo)
 "aYp" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
@@ -11028,10 +11028,10 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "aYI" = (
-/obj/machinery/rnd/production/techfab/department/cargo,
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/machinery/vending/wardrobe/cargo_wardrobe,
 /turf/open/floor/plasteel/mil,
 /area/quartermaster/storage)
 "aYJ" = (
@@ -11376,8 +11376,7 @@
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bhM" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/maintenance/department/cargo)
 "biw" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -12036,12 +12035,9 @@
 /turf/open/floor/plasteel/dark,
 /area/science/research)
 "dri" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/machinery/autolathe,
-/turf/open/floor/plasteel/mil,
-/area/quartermaster/storage)
+/obj/structure/closet/crate/internals,
+/turf/open/floor/plasteel/mil/cargo,
+/area/quartermaster/warehouse)
 "dtM" = (
 /obj/effect/decal/cleanable/greenglow,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -13188,8 +13184,7 @@
 /turf/open/floor/plating,
 /area/tcommsat/server/upper)
 "gAQ" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/mil,
 /area/maintenance/department/cargo)
 "gBI" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -14121,6 +14116,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 1
 	},
+/obj/structure/railing,
+/obj/structure/railing/corner,
 /turf/open/floor/plasteel/mil,
 /area/quartermaster/warehouse)
 "jqN" = (
@@ -14335,6 +14332,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
+"jMz" = (
+/obj/machinery/door/airlock/mining/glass{
+	name = "Quartermaster";
+	req_access_txt = "41"
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/department/cargo)
 "jMA" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -15121,6 +15125,12 @@
 /obj/item/stack/tile/plasteel,
 /turf/open/space/basic,
 /area/maintenance/port/aft)
+"mml" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	req_access_txt = "41"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "mon" = (
 /obj/effect/landmark/start/head_of_security,
 /obj/structure/chair/office{
@@ -15611,6 +15621,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 4
 	},
+/obj/effect/turf_decal/siding/white/corner,
 /turf/open/floor/plasteel,
 /area/science/research)
 "nQT" = (
@@ -15886,17 +15897,11 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
 	dir = 1
 	},
-/obj/structure/closet/secure_closet/quartermaster,
-/obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/structure/window/reinforced/spawner/west,
-/obj/structure/window/reinforced/spawner/east,
-/obj/machinery/door/window/brigdoor/northleft{
-	req_access_txt = "30"
-	},
+/obj/machinery/rnd/production/techfab/department/cargo,
 /turf/open/floor/plasteel/mil,
 /area/quartermaster/storage)
 "oAF" = (
@@ -16036,6 +16041,9 @@
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -28
+	},
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark/side{
 	dir = 4
@@ -16612,6 +16620,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
+/obj/effect/turf_decal/siding/white,
 /turf/open/floor/plasteel,
 /area/science/research)
 "qIp" = (
@@ -16998,6 +17007,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
+/obj/effect/turf_decal/siding/white,
 /turf/open/floor/plasteel,
 /area/science/research)
 "rSO" = (
@@ -17160,7 +17170,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "sjs" = (
-/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 5
 	},
@@ -17496,8 +17505,7 @@
 /area/bridge)
 "tfH" = (
 /obj/machinery/piratepad/civilian,
-/obj/structure/window/reinforced/spawner/north,
-/turf/open/floor/plasteel/mil,
+/turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "tfN" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -17517,7 +17525,13 @@
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "tgg" = (
-/turf/open/floor/plasteel/mil/cargo,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/stairs{
+	dir = 8
+	},
+/turf/open/floor/plating,
 /area/quartermaster/warehouse)
 "tgV" = (
 /obj/machinery/light{
@@ -18319,11 +18333,11 @@
 	},
 /obj/structure/table,
 /obj/machinery/cell_charger,
-/obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/item/stock_parts/cell/high,
 /turf/open/floor/plasteel/mil,
 /area/quartermaster/storage)
 "vxH" = (
@@ -18583,12 +18597,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/vending/wardrobe/cargo_wardrobe,
-/obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/autolathe,
 /turf/open/floor/plasteel/mil,
 /area/quartermaster/storage)
 "wec" = (
@@ -19088,6 +19101,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/theatre)
+"xmo" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	req_access_txt = "41"
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/department/cargo)
 "xnb" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -19279,6 +19298,10 @@
 /obj/effect/spawner/lootdrop/armory_contraband,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
+"xIJ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "xJn" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /obj/effect/turf_decal/stripes/line,
@@ -48859,9 +48882,9 @@ aKM
 axK
 aQx
 iRn
-iRn
-iRn
-aYo
+dri
+aGE
+acj
 acj
 gvS
 ahK
@@ -51945,8 +51968,8 @@ aDc
 oHO
 dJM
 ago
-dri
-aZK
+aZZ
+aZZ
 fTZ
 aCb
 aHA
@@ -52201,8 +52224,8 @@ aZK
 aDc
 aJJ
 gad
-aGE
 aVn
+aZK
 atu
 trs
 alK
@@ -52459,7 +52482,7 @@ aDc
 aTZ
 jCI
 aVn
-ahb
+aZK
 tfH
 fTZ
 kLf
@@ -114393,11 +114416,11 @@ lFz
 lFz
 lFz
 aFz
-aww
-aww
 gAQ
-aww
-aww
+gAQ
+gAQ
+gAQ
+gAQ
 afh
 tSm
 akS
@@ -114650,11 +114673,11 @@ lFz
 eLx
 eLx
 aFz
-aww
-aww
 gAQ
-aww
-aww
+gAQ
+gAQ
+ahb
+arU
 afh
 tSm
 akS
@@ -114907,11 +114930,11 @@ lFz
 eLx
 lFz
 aFz
-aww
-aww
 gAQ
-aww
-aww
+gAQ
+gAQ
+ahb
+arU
 afh
 tSm
 akS
@@ -115164,11 +115187,11 @@ eLx
 eLx
 aLs
 aFz
-aww
-aww
-gAQ
-aww
-aww
+aLD
+afh
+jMz
+afh
+aLD
 afh
 jNW
 aJl
@@ -115421,11 +115444,11 @@ ckA
 ckA
 ckA
 aFz
-aww
-aww
-gAQ
-aww
-aww
+bhM
+bhM
+bhM
+bhM
+bhM
 afh
 tSm
 akS
@@ -115677,13 +115700,13 @@ ckA
 ckA
 ckA
 ckA
-aFz
-aww
-aww
-gAQ
-aww
-aww
-acV
+xIJ
+bhM
+bhM
+bhM
+bhM
+bhM
+xmo
 tSm
 akS
 aSE
@@ -115934,12 +115957,12 @@ ckA
 ckA
 ckA
 ckA
-aFz
-aww
-aww
-gAQ
-aww
-aww
+xIJ
+bhM
+bhM
+bhM
+bhM
+bhM
 afh
 tSm
 akS
@@ -116191,12 +116214,12 @@ ckA
 ckA
 ckA
 ckA
-aFz
+xIJ
 bhM
-aww
-gAQ
-aww
-aww
+bhM
+bhM
+bhM
+bhM
 afh
 tSm
 akS
@@ -116448,12 +116471,12 @@ ckA
 ckA
 ckA
 ckA
-aFz
-aLD
-gAQ
-gAQ
-aww
-aww
+xIJ
+bhM
+bhM
+bhM
+bhM
+bhM
 afh
 tSm
 hSv
@@ -116706,11 +116729,11 @@ ckA
 ckA
 ckA
 aFz
-aww
-aww
-aww
-aww
-aww
+aYo
+bhM
+bhM
+bhM
+bhM
 afh
 tSm
 akS
@@ -116965,7 +116988,7 @@ ckA
 aFz
 afh
 afh
-acV
+mml
 afh
 afh
 afh

--- a/_maps/map_files/HoleStation/holestation.dmm
+++ b/_maps/map_files/HoleStation/holestation.dmm
@@ -402,6 +402,9 @@
 /area/engine/supermatter)
 "abN" = (
 /obj/machinery/nanite_program_hub,
+/obj/structure/sign/departments/nanites{
+	pixel_x = 32
+	},
 /turf/open/floor/plasteel/dark/side,
 /area/science/research)
 "abP" = (
@@ -662,6 +665,7 @@
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_access_txt = "12"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "acW" = (
@@ -796,8 +800,15 @@
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_access_txt = "31"
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/mil,
+/area/maintenance/central)
 "adK" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken3"
@@ -1402,8 +1413,9 @@
 /area/crew_quarters/heads/captain)
 "ahb" = (
 /obj/structure/railing,
+/obj/effect/turf_decal/siding/green,
 /turf/open/floor/plasteel/mil,
-/area/maintenance/department/cargo)
+/area/quartermaster/warehouse)
 "ahd" = (
 /obj/effect/turf_decal/tile/blue/diagonal,
 /turf/open/floor/plasteel,
@@ -3253,19 +3265,13 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "apa" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/flora/ausbushes/genericbush,
-/obj/structure/flora/ausbushes/leafybush,
-/turf/open/floor/grass,
-/area/hydroponics)
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "apb" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/lavendergrass,
-/turf/open/floor/grass,
-/area/hydroponics)
+/turf/closed/wall,
+/area/quartermaster/qm)
 "apc" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/clothing/under/costume/gladiator,
@@ -3883,12 +3889,10 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "arZ" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -28
+/obj/effect/turf_decal/siding/green{
+	dir = 8
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/mil,
+/turf/open/floor/plasteel/mil/box,
 /area/quartermaster/warehouse)
 "asa" = (
 /obj/structure/sign/painting/library{
@@ -3940,9 +3944,12 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "asm" = (
-/obj/effect/landmark/start/quartermaster,
-/turf/open/floor/plasteel/mil,
-/area/quartermaster/storage)
+/obj/structure/reagent_dispensers/water_cooler,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/qm)
 "aso" = (
 /obj/structure/table,
 /turf/open/floor/plasteel,
@@ -4847,7 +4854,15 @@
 "awH" = (
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
-/turf/open/floor/plasteel/mil,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -28
+	},
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/structure/closet/crate/medical,
+/turf/open/floor/plasteel/mil/cargo,
 /area/quartermaster/warehouse)
 "awK" = (
 /obj/structure/table,
@@ -5927,6 +5942,20 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/structure/sign/directions/medical{
+	pixel_y = -40
+	},
+/obj/structure/sign/directions/science{
+	pixel_y = -22;
+	dir = 8
+	},
+/obj/structure/sign/directions/security{
+	pixel_y = -28;
+	dir = 8
+	},
+/obj/structure/sign/directions/supply{
+	pixel_y = -34
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aBS" = (
@@ -6854,6 +6883,7 @@
 /area/maintenance/starboard/aft)
 "aGf" = (
 /obj/effect/landmark/xeno_spawn,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aGg" = (
@@ -6959,10 +6989,24 @@
 /turf/open/floor/plasteel,
 /area/science/lab)
 "aGE" = (
-/obj/structure/closet/crate/medical,
-/obj/structure/railing/corner,
-/turf/open/floor/plasteel/mil/cargo,
-/area/quartermaster/warehouse)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/sign/directions/medical{
+	pixel_y = -40;
+	dir = 4
+	},
+/obj/structure/sign/directions/science{
+	pixel_y = -22
+	},
+/obj/structure/sign/directions/security{
+	pixel_y = -28
+	},
+/obj/structure/sign/directions/supply{
+	pixel_y = -34
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "aGF" = (
 /obj/structure/railing{
 	dir = 1
@@ -7274,6 +7318,9 @@
 "aHZ" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/chem_master,
+/obj/structure/sign/departments/xenobio{
+	pixel_x = 32
+	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "aIa" = (
@@ -7903,6 +7950,11 @@
 /obj/effect/turf_decal/bot_red,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"aKQ" = (
+/obj/effect/spawner/structure/window/hollow/middle,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "aKR" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/turf_decal/stripes/line{
@@ -8043,7 +8095,7 @@
 "aLD" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/quartermaster/warehouse)
 "aLH" = (
 /obj/structure/sign/painting/library{
 	pixel_x = 32
@@ -9177,9 +9229,6 @@
 /turf/open/floor/mineral/plastitanium,
 /area/science/research)
 "aQz" = (
-/obj/structure/closet/crate{
-	name = "spare parts"
-	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -9584,6 +9633,9 @@
 /obj/item/clothing/glasses/meson/engine,
 /obj/effect/turf_decal/tile/neutral/half/contrast{
 	dir = 4
+	},
+/obj/structure/sign/departments/tcomms{
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
@@ -10160,6 +10212,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/nuke_storage)
+"aUI" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 8
+	},
+/turf/open/transparent/openspace,
+/area/maintenance/central)
 "aUL" = (
 /obj/effect/landmark/start/depsec/science,
 /obj/effect/turf_decal/stripes{
@@ -10930,9 +10993,15 @@
 /turf/open/floor/plasteel,
 /area/engine/supermatter)
 "aYo" = (
-/obj/structure/closet/secure_closet/quartermaster,
-/turf/open/floor/plasteel,
-/area/maintenance/department/cargo)
+/obj/machinery/computer/cargo{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow/whole,
+/obj/effect/turf_decal/siding/yellow{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark/whole,
+/area/quartermaster/qm)
 "aYp" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
@@ -11001,8 +11070,7 @@
 /turf/open/floor/wood,
 /area/quartermaster/storage)
 "aYA" = (
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/mil,
+/turf/open/floor/plasteel/mil/box,
 /area/quartermaster/storage)
 "aYC" = (
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -11376,7 +11444,21 @@
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bhM" = (
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel/anticorner{
+	dir = 8
+	},
+/area/quartermaster/qm)
+"bin" = (
+/obj/structure/safe/floor,
+/obj/item/clothing/under/syndicate,
+/obj/item/clothing/under/syndicate/skirt,
+/obj/item/clothing/head/hos/beret/syndicate,
+/obj/item/clothing/gloves/combat,
+/obj/item/clothing/shoes/combat,
+/turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "biw" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -11448,6 +11530,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bui" = (
@@ -11702,6 +11785,15 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"ciY" = (
+/obj/structure/table/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/quartermaster/qm)
 "ckA" = (
 /turf/open/transparent/openspace/airless,
 /area/space)
@@ -11738,6 +11830,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
 /turf/open/floor/plasteel/white,
 /area/medical)
+"cuG" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/qm)
 "cvf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -11828,6 +11926,7 @@
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_access_txt = "12"
 	},
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cIp" = (
@@ -11958,6 +12057,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "dgK" = (
@@ -11989,6 +12089,10 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"dkT" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "dlW" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/machinery/vending/wardrobe/hydro_wardrobe,
@@ -12165,6 +12269,16 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engine/engine_smes)
+"dQs" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "dTx" = (
 /obj/machinery/light{
 	dir = 1
@@ -12210,6 +12324,9 @@
 /area/maintenance/central/secondary)
 "dYj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/turf_decal/tile/green/half/contrast{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "dZb" = (
@@ -12594,6 +12711,33 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"fiO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/structure/sign/directions/command{
+	pixel_y = 42;
+	dir = 1
+	},
+/obj/structure/sign/directions/dorms{
+	pixel_y = 36;
+	dir = 4
+	},
+/obj/structure/sign/directions/engineering{
+	pixel_y = 30;
+	dir = 4
+	},
+/obj/structure/sign/directions/evac{
+	pixel_y = 24;
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "fki" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/structure/window/reinforced,
@@ -12688,6 +12832,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"fzz" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "fzA" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -13144,14 +13292,27 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/obj/item/radio/intercom{
-	pixel_y = 24
-	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/structure/sign/directions/medical{
+	pixel_y = 42;
+	dir = 4
+	},
+/obj/structure/sign/directions/science{
+	pixel_y = 36;
+	dir = 1
+	},
+/obj/structure/sign/directions/security{
+	pixel_y = 30;
+	dir = 8
+	},
+/obj/structure/sign/directions/supply{
+	pixel_y = 24;
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "gxP" = (
@@ -13184,8 +13345,13 @@
 /turf/open/floor/plating,
 /area/tcommsat/server/upper)
 "gAQ" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/siding/green,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 1
+	},
 /turf/open/floor/plasteel/mil,
-/area/maintenance/department/cargo)
+/area/quartermaster/warehouse)
 "gBI" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -13300,6 +13466,11 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/toilet)
+"gUx" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/plasteel,
+/area/quartermaster/qm)
 "gUO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -13412,6 +13583,18 @@
 	},
 /turf/open/floor/wood,
 /area/security/brig)
+"hvQ" = (
+/obj/structure/closet/secure_closet/quartermaster,
+/obj/effect/turf_decal/tile/yellow/whole,
+/obj/effect/turf_decal/siding/yellow{
+	dir = 9
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/turf/open/floor/plasteel/dark/whole,
+/area/quartermaster/qm)
 "hwG" = (
 /obj/structure/sign/nanotrasen{
 	pixel_y = 32
@@ -13613,6 +13796,21 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 1
 	},
+/obj/structure/sign/directions/command{
+	pixel_y = -22;
+	dir = 4
+	},
+/obj/structure/sign/directions/dorms{
+	pixel_y = -28;
+	dir = 4
+	},
+/obj/structure/sign/directions/engineering{
+	pixel_y = -34
+	},
+/obj/structure/sign/directions/evac{
+	pixel_y = -40;
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "igw" = (
@@ -13684,6 +13882,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "ire" = (
@@ -13890,6 +14091,10 @@
 "iRn" = (
 /turf/open/floor/plasteel/mil,
 /area/quartermaster/warehouse)
+"iSc" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "iSi" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/transparent/glass,
@@ -14117,8 +14322,7 @@
 	dir = 1
 	},
 /obj/structure/railing,
-/obj/structure/railing/corner,
-/turf/open/floor/plasteel/mil,
+/turf/open/floor/plasteel/mil/cargo,
 /area/quartermaster/warehouse)
 "jqN" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -14259,8 +14463,15 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"jFd" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
+/turf/open/floor/plasteel/mil/cargo,
+/area/quartermaster/warehouse)
 "jFA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 5
@@ -14332,13 +14543,34 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
+"jLQ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
+/obj/structure/cable,
+/turf/open/floor/plasteel/mil/cargo/arrow,
+/area/quartermaster/warehouse)
 "jMz" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Quartermaster";
 	req_access_txt = "41"
 	},
-/turf/open/floor/plasteel,
-/area/maintenance/department/cargo)
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/mil,
+/area/quartermaster/warehouse)
 "jMA" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -14355,6 +14587,12 @@
 /obj/structure/cable,
 /turf/open/transparent/openspace,
 /area/maintenance/central)
+"jOb" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/qm)
 "jPF" = (
 /obj/item/clothing/head/fedora,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -14496,6 +14734,19 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/mil,
 /area/quartermaster/storage)
+"kkj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/brown/half/contrast{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/qm)
 "kmc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
@@ -14605,6 +14856,17 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"kyY" = (
+/turf/open/floor/plasteel/anticorner{
+	dir = 1
+	},
+/area/quartermaster/qm)
+"kCy" = (
+/obj/structure/sign/departments/mait{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "kEw" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -14917,6 +15179,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"lst" = (
+/obj/structure/closet/crate{
+	name = "spare parts"
+	},
+/turf/open/floor/plasteel/mil/cargo,
+/area/quartermaster/warehouse)
 "lsS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
@@ -14979,6 +15247,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
+"lFn" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/plasteel/mil/cargo,
+/area/quartermaster/warehouse)
 "lFz" = (
 /turf/open/floor/engine/hull,
 /area/space/nearstation)
@@ -15022,6 +15294,25 @@
 /obj/effect/spawner/structure/window/hollow/end,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"lKY" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/sign/directions/command{
+	pixel_y = -22;
+	dir = 8
+	},
+/obj/structure/sign/directions/dorms{
+	pixel_y = -28
+	},
+/obj/structure/sign/directions/engineering{
+	pixel_y = -34
+	},
+/obj/structure/sign/directions/evac{
+	pixel_y = -40
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "lQf" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -15060,6 +15351,9 @@
 /obj/structure/railing{
 	dir = 1
 	},
+/obj/machinery/vending/wallmed{
+	pixel_x = -28
+	},
 /turf/open/floor/plating,
 /area/medical)
 "lWB" = (
@@ -15072,6 +15366,11 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/mil,
 /area/quartermaster/miningdock)
+"lWM" = (
+/obj/structure/cable,
+/obj/structure/window,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "lYl" = (
 /obj/machinery/light{
 	dir = 8
@@ -15126,11 +15425,9 @@
 /turf/open/space/basic,
 /area/maintenance/port/aft)
 "mml" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_access_txt = "41"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/obj/effect/turf_decal/tile/brown/diagonal,
+/turf/open/floor/plasteel/dark,
+/area/quartermaster/qm)
 "mon" = (
 /obj/effect/landmark/start/head_of_security,
 /obj/structure/chair/office{
@@ -15286,6 +15583,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 1
 	},
+/obj/item/radio/intercom{
+	pixel_y = -28
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "mVC" = (
@@ -15399,6 +15699,16 @@
 "nfK" = (
 /turf/closed/wall/r_wall,
 /area/medical/sleeper)
+"nfZ" = (
+/obj/structure/closet/firecloset/full,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/sign/departments/mait{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "ngo" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -15410,6 +15720,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -15551,6 +15864,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
+"nIA" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/north,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "nIK" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -15598,6 +15916,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"nNE" = (
+/obj/structure/chair,
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "nOC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/box,
@@ -15911,6 +16233,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"oBj" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "oBG" = (
 /obj/structure/railing,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
@@ -15933,6 +16260,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
+"oDa" = (
+/obj/machinery/suit_storage_unit/mining/eva,
+/obj/effect/turf_decal/tile/yellow/whole,
+/obj/effect/turf_decal/siding/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/whole,
+/area/quartermaster/qm)
 "oDb" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/rack,
@@ -15992,6 +16327,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit)
+"oFy" = (
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown/diagonal,
+/obj/effect/landmark/start/quartermaster,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/quartermaster/qm)
 "oFW" = (
 /mob/living/simple_animal/parrot/poly,
 /turf/open/floor/engine/hull/reinforced,
@@ -16159,6 +16505,9 @@
 "peL" = (
 /obj/structure/chair/office/light,
 /obj/effect/landmark/start/virologist,
+/obj/effect/turf_decal/tile/green/half/contrast{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "pfe" = (
@@ -16253,6 +16602,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"pwl" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/west,
+/turf/open/floor/plasteel,
+/area/quartermaster/qm)
 "pxp" = (
 /obj/item/radio/intercom{
 	pixel_y = 22
@@ -16355,6 +16709,17 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"pRP" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/turf/open/transparent/openspace,
+/area/maintenance/central)
 "pUO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
@@ -16436,6 +16801,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
+"qgN" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin/bundlenatural,
+/obj/item/pen,
+/obj/item/stamp/qm,
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/quartermaster/qm)
 "qgQ" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/effect/turf_decal/stripes/line{
@@ -16511,6 +16885,9 @@
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_access_txt = "12"
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
@@ -16596,6 +16973,22 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/structure/sign/directions/command{
+	pixel_y = 42;
+	dir = 1
+	},
+/obj/structure/sign/directions/dorms{
+	pixel_y = 36;
+	dir = 4
+	},
+/obj/structure/sign/directions/engineering{
+	pixel_y = 30;
+	dir = 8
+	},
+/obj/structure/sign/directions/evac{
+	pixel_y = 24;
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "qFc" = (
@@ -16900,6 +17293,16 @@
 	},
 /turf/open/floor/plasteel/mil,
 /area/hallway/secondary/service)
+"rCu" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/mil/cargo/arrow,
+/area/quartermaster/warehouse)
 "rDX" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -16922,6 +17325,16 @@
 /obj/effect/landmark/start/chemist,
 /turf/open/floor/plasteel/white,
 /area/medical/office)
+"rFD" = (
+/obj/machinery/computer/security/qm{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow/whole,
+/obj/effect/turf_decal/siding/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/whole,
+/area/quartermaster/qm)
 "rIp" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external/glass{
@@ -17017,6 +17430,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/structure/table,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "rTO" = (
@@ -17141,6 +17555,17 @@
 	},
 /turf/open/floor/plasteel/mil,
 /area/crew_quarters/bar/atrium)
+"sdy" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "sdW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/camera/autoname{
@@ -17167,6 +17592,7 @@
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_access_txt = "12"
 	},
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "sjs" = (
@@ -17342,6 +17768,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft/secondary)
+"sBE" = (
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/mil,
+/area/quartermaster/warehouse)
+"sBJ" = (
+/obj/structure/grille,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
+"sDk" = (
+/obj/effect/turf_decal/siding/green/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mil,
+/area/quartermaster/warehouse)
 "sDI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -17529,7 +17970,7 @@
 	dir = 5
 	},
 /obj/structure/stairs{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
@@ -17663,8 +18104,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"txG" = (
+/obj/effect/spawner/structure/window/hollow/directional,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "txM" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -17760,6 +18207,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical)
+"tGz" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	req_access_txt = "41"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "tHV" = (
 /obj/machinery/holopad,
 /obj/effect/landmark/start/botanist,
@@ -17963,6 +18422,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"ueU" = (
+/obj/effect/turf_decal/tile/brown/diagonal,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
+/turf/open/floor/plasteel/dark,
+/area/quartermaster/qm)
 "una" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass,
@@ -18036,6 +18500,11 @@
 /obj/structure/cable,
 /turf/open/transparent/openspace,
 /area/maintenance/central/secondary)
+"uvE" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "uwi" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
@@ -18233,9 +18702,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "vdB" = (
-/obj/machinery/vending/wallmed{
-	pixel_x = 24
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 9
 	},
@@ -18245,6 +18711,11 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/medical)
+"vey" = (
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/quartermaster/qm)
 "vff" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 10
@@ -18273,6 +18744,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "vhp" = (
@@ -18303,6 +18775,19 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"vqD" = (
+/turf/closed/wall/r_wall,
+/area/quartermaster/warehouse)
+"vsv" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "vsI" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
@@ -18716,6 +19201,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"wlX" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/quartermaster/qm)
 "wlZ" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/engine/o2,
@@ -18762,6 +19253,18 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
+"wsj" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/qm)
 "wsR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
@@ -19102,11 +19605,38 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/theatre)
 "xmo" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	req_access_txt = "41"
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/quartermaster/qm)
+"xmv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/sign/directions/medical{
+	pixel_y = 42;
+	dir = 1
+	},
+/obj/structure/sign/directions/science{
+	pixel_y = 36;
+	dir = 8
+	},
+/obj/structure/sign/directions/security{
+	pixel_y = 30;
+	dir = 8
+	},
+/obj/structure/sign/directions/supply{
+	pixel_y = 24;
+	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/maintenance/department/cargo)
+/area/hallway/primary/central)
 "xnb" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -19142,6 +19672,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/central)
 "xoR" = (
@@ -19171,6 +19704,9 @@
 /area/maintenance/port/aft)
 "xsr" = (
 /obj/machinery/rnd/production/techfab/department/medical,
+/obj/structure/sign/departments/examroom{
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel/white,
 /area/medical)
 "xvT" = (
@@ -19225,6 +19761,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
+"xDK" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/hollow,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "xEO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
@@ -19258,6 +19799,7 @@
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_access_txt = "12"
 	},
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "xHB" = (
@@ -19299,9 +19841,8 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "xIJ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/turf/closed/wall/r_wall,
+/area/quartermaster/qm)
 "xJn" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /obj/effect/turf_decal/stripes/line,
@@ -19374,6 +19915,9 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"xQI" = (
+/turf/open/transparent/openspace,
+/area/quartermaster/warehouse)
 "xQV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
@@ -19411,6 +19955,9 @@
 /obj/machinery/vending/wardrobe/chem_wardrobe,
 /obj/structure/window/reinforced,
 /obj/machinery/door/firedoor/heavy,
+/obj/structure/sign/departments/chemistry/pharmacy{
+	pixel_x = 32
+	},
 /turf/open/floor/plasteel/mil,
 /area/medical/office)
 "xZv" = (
@@ -19431,6 +19978,11 @@
 /obj/structure/cable/layer3,
 /turf/open/floor/plating,
 /area/engine/engine_room)
+"yek" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "yfj" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -19442,6 +19994,9 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"yfH" = (
+/turf/open/floor/plasteel/dark,
+/area/quartermaster/qm)
 "yjt" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
 	dir = 8
@@ -47089,7 +47644,7 @@ aQc
 abV
 rNA
 aCb
-app
+nfZ
 azO
 azO
 aPc
@@ -48629,7 +49184,7 @@ azq
 azq
 acj
 acj
-lcN
+fiO
 mUy
 aSr
 aAq
@@ -48864,7 +49419,7 @@ ajB
 ajB
 vFn
 ifW
-aoW
+aoU
 arh
 arh
 arh
@@ -48882,9 +49437,9 @@ aKM
 axK
 aQx
 iRn
-dri
-aGE
-acj
+iRn
+iRn
+sBE
 acj
 gvS
 ahK
@@ -49120,9 +49675,9 @@ aMj
 ajF
 aln
 aPZ
-ahK
-apa
-arh
+aGE
+aoU
+nNE
 sdf
 cIp
 tHV
@@ -49378,7 +49933,7 @@ aeZ
 alt
 aPZ
 ahK
-apb
+aoW
 arf
 hKL
 auy
@@ -49398,7 +49953,7 @@ auh
 ayt
 fKe
 awH
-arZ
+acj
 acj
 sWQ
 ahK
@@ -50937,7 +51492,7 @@ anZ
 aMX
 aOi
 aVn
-asm
+aVn
 vwT
 aVn
 aRu
@@ -52463,7 +53018,7 @@ tlT
 ewV
 ahK
 apy
-arD
+aSR
 fQg
 mXp
 awR
@@ -53232,7 +53787,7 @@ aam
 akC
 kRJ
 aPZ
-ahK
+lKY
 apy
 aYt
 qbM
@@ -53491,7 +54046,7 @@ akD
 bwB
 aBR
 apy
-aSR
+arD
 xis
 mXp
 axk
@@ -53769,7 +54324,7 @@ aUe
 aUe
 aOz
 aOz
-fTZ
+xmv
 aCj
 aHA
 avr
@@ -55836,7 +56391,7 @@ aiL
 aJy
 aIk
 aCk
-adF
+kCy
 aJB
 aSz
 aWN
@@ -113403,7 +113958,7 @@ nYC
 wRn
 alj
 azO
-aku
+yek
 pek
 iSi
 azO
@@ -113647,7 +114202,7 @@ rOK
 rOK
 rOK
 rOK
-rOK
+aUI
 bqt
 rOK
 pmf
@@ -113904,7 +114459,7 @@ akS
 akS
 akS
 akS
-hSv
+pRP
 akS
 akS
 aJl
@@ -114158,13 +114713,13 @@ aEK
 aEK
 aEK
 aSE
-aFz
-afh
-afh
+aSE
+aZt
+aZt
 adI
-afh
-afh
-afh
+aZt
+aZt
+aZt
 tSm
 akS
 aEK
@@ -114415,13 +114970,13 @@ lFz
 lFz
 lFz
 lFz
-aFz
+vqD
+lFn
+lst
+rCu
 gAQ
-gAQ
-gAQ
-gAQ
-gAQ
-afh
+xQI
+aZt
 tSm
 akS
 aEK
@@ -114672,13 +115227,13 @@ lFz
 lFz
 eLx
 eLx
-aFz
-gAQ
-gAQ
-gAQ
+vqD
+iRn
+iRn
+fKe
 ahb
-arU
-afh
+xQI
+aZt
 tSm
 akS
 aEK
@@ -114929,13 +115484,13 @@ lFz
 lFz
 eLx
 lFz
-aFz
-gAQ
-gAQ
-gAQ
-ahb
-arU
-afh
+vqD
+dri
+jFd
+jLQ
+sDk
+arZ
+aZt
 tSm
 akS
 aSE
@@ -115186,13 +115741,13 @@ eLx
 eLx
 eLx
 aLs
-aFz
+vqD
 aLD
-afh
+acj
 jMz
-afh
+acj
 aLD
-afh
+aZt
 jNW
 aJl
 aSE
@@ -115443,13 +115998,13 @@ ckA
 ckA
 ckA
 ckA
-aFz
-bhM
-bhM
-bhM
-bhM
-bhM
-afh
+xIJ
+asm
+gUx
+kkj
+pwl
+cuG
+apb
 tSm
 akS
 aSE
@@ -115700,12 +116255,12 @@ ckA
 ckA
 ckA
 ckA
-xIJ
+xmo
+jOb
+kyY
+wsj
 bhM
-bhM
-bhM
-bhM
-bhM
+cuG
 xmo
 tSm
 akS
@@ -115957,13 +116512,13 @@ ckA
 ckA
 ckA
 ckA
-xIJ
-bhM
-bhM
-bhM
-bhM
-bhM
-afh
+xmo
+vey
+qgN
+ciY
+wlX
+vey
+xmo
 tSm
 akS
 aSE
@@ -116214,13 +116769,13 @@ ckA
 ckA
 ckA
 ckA
-xIJ
-bhM
-bhM
-bhM
-bhM
-bhM
-afh
+xmo
+mml
+ueU
+oFy
+mml
+mml
+xmo
 tSm
 akS
 akS
@@ -116472,12 +117027,12 @@ ckA
 ckA
 ckA
 xIJ
-bhM
-bhM
-bhM
-bhM
-bhM
-afh
+rFD
+aYo
+yfH
+hvQ
+oDa
+apb
 tSm
 hSv
 hSv
@@ -116729,11 +117284,11 @@ ckA
 ckA
 ckA
 aFz
-aYo
-bhM
-bhM
-bhM
-bhM
+afh
+afh
+tGz
+afh
+afh
 afh
 tSm
 akS
@@ -116986,12 +117541,12 @@ ckA
 ckA
 ckA
 aFz
+bin
+aKQ
+aww
+dkT
 afh
-afh
-mml
-afh
-afh
-afh
+wTs
 tSm
 akS
 akS
@@ -117243,12 +117798,12 @@ ckA
 ckA
 ckA
 aFz
+sBJ
+txG
 aww
-aww
-aww
-aww
+uvE
 afh
-wTs
+qhU
 tSm
 akS
 akS
@@ -117500,10 +118055,10 @@ ckA
 ckA
 ckA
 aFz
+apa
+lWM
 aww
-aww
-aww
-aww
+fzz
 afh
 qhU
 tSm
@@ -117758,11 +118313,11 @@ ckA
 ckA
 aFz
 aww
-aww
+xDK
 aGf
-aww
+iSc
 acV
-qhU
+oBj
 tSm
 aKZ
 avw
@@ -118014,8 +118569,8 @@ ckA
 ckA
 ckA
 aFz
-aww
-aww
+nIA
+iSc
 aww
 aww
 afh
@@ -118271,9 +118826,9 @@ ckA
 ckA
 ckA
 aFz
-rSO
-rSO
-rSO
+dQs
+vsv
+sdy
 rSO
 afh
 afh


### PR DESCRIPTION
Lookit mapdiffbot, summarized version in CL

also call me <ss13 head maintainer you dislike here> because i'm self merging baybee

## Changelog
:cl:
add: Holestation has received Lawyers and Psychologists, bringing it up to a full roster.
add: The RD now has an office on Holestation... with a catch.
add: The QM has received an RD on office for free. While laughing at the RD.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
