### PR TITLE
Over-Plating Catwalks

### DIFF
--- a/_maps/map_files/HoleStation/holestation.dmm
+++ b/_maps/map_files/HoleStation/holestation.dmm
@@ -432,6 +432,7 @@
 /area/science/research)
 "abU" = (
 /obj/structure/cable,
+/obj/structure/lattice/catwalk/over,
 /turf/open/floor/plating,
 /area/hallway/primary/central)
 "abV" = (
@@ -4141,7 +4142,7 @@
 "atu" = (
 /obj/machinery/computer/piratepad_control/civilian,
 /turf/open/floor/plasteel,
-/area/quartermaster/storage)
+/area/hallway/primary/central)
 "atw" = (
 /turf/open/floor/plasteel/dark/side{
 	dir = 4
@@ -9748,6 +9749,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/structure/lattice/catwalk/over,
 /turf/open/floor/plating,
 /area/hallway/primary/central)
 "aSV" = (
@@ -11964,6 +11966,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/structure/cable,
+/obj/structure/lattice/catwalk/over,
 /turf/open/floor/plating,
 /area/hallway/primary/central)
 "dhT" = (
@@ -17080,6 +17083,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/structure/cable,
+/obj/structure/lattice/catwalk/over,
 /turf/open/floor/plating,
 /area/hallway/primary/central)
 "rbn" = (
@@ -17919,7 +17923,7 @@
 "tfH" = (
 /obj/machinery/piratepad/civilian,
 /turf/open/floor/plasteel,
-/area/quartermaster/storage)
+/area/hallway/primary/central)
 "tfN" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/landmark/start/prisoner,

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -82,17 +82,23 @@
 /obj/structure/lattice/catwalk/deconstruction_hints(mob/user)
 	return "<span class='notice'>The supporting rods look like they could be <b>cut</b>.</span>"
 
-/obj/structure/lattice/catwalk/Move()
+/obj/structure/lattice/catwalk/proc/cablecheck()
 	var/turf/T = loc
-	for(var/obj/structure/cable/C in T)
+	for(var/obj/structure/cable/C in T && layer >> WIRE_TERMINAL_LAYER)
 		C.deconstruct()
+
+/obj/structure/lattice/catwalk/Move()
+	cablecheck()
 	..()
 
 /obj/structure/lattice/catwalk/deconstruct()
-	var/turf/T = loc
-	for(var/obj/structure/cable/C in T)
-		C.deconstruct()
+	cablecheck()
 	..()
+
+/// A variant of catwalks placed over plating.
+/obj/structure/lattice/catwalk/over
+	layer = LOW_OBJ_LAYER
+	plane = GAME_PLANE
 
 /obj/structure/lattice/lava
 	name = "heatproof support lattice"

--- a/code/game/turfs/open/floor/plating.dm
+++ b/code/game/turfs/open/floor/plating.dm
@@ -62,7 +62,7 @@
 			var/obj/item/stack/rods/R = C
 			if (R.use(2))
 				to_chat(user, "<span class='notice'>You lay down the catwalk.</span>")
-				playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
+				playsound(src, 'sound/weapons/Genhit.ogg', 50, TRUE)
 				new /obj/structure/lattice/catwalk/over(src)
 				return
 	if(istype(C, /obj/item/stack/sheet/metal) && attachment_holes)

--- a/code/game/turfs/open/floor/plating.dm
+++ b/code/game/turfs/open/floor/plating.dm
@@ -25,7 +25,7 @@
 		. += "<span class='notice'>It looks like the dents could be <i>welded</i> smooth.</span>"
 		return
 	if(attachment_holes)
-		. += "<span class='notice'>There are a few attachment holes for a new <i>tile</i> or reinforcement <i>rods</i>.</span>"
+		. += "<span class='notice'>There are a few attachment holes for a new <i>tile</i>, reinforcement <i>sheets</i> or catwalk <i>rods</i>.</span>"
 	else
 		. += "<span class='notice'>You might be able to build ontop of it with some <i>tiles</i>...</span>"
 
@@ -56,20 +56,33 @@
 			else
 				to_chat(user, "<span class='warning'>Repair the plating first! Use a welding tool or a plating repair tool to fix the damage.</span>") //we don't need to confuse humans by giving them a message about plating repair tools, since only janiborgs should have access to them outside of Christmas presents or admin intervention
 			return
-		var/obj/item/stack/rods/R = C
-		if (R.get_amount() < 2)
-			to_chat(user, "<span class='warning'>You need two rods to make a reinforced floor!</span>")
+		if(locate(/obj/structure/lattice/catwalk/over, src))
+			return
+		if (istype(C, /obj/item/stack/rods))
+			var/obj/item/stack/rods/R = C
+			if (R.use(2))
+				to_chat(user, "<span class='notice'>You lay down the catwalk.</span>")
+				playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
+				new /obj/structure/lattice/catwalk/over(src)
+				return
+	if(istype(C, /obj/item/stack/sheet/metal) && attachment_holes)
+		if(broken || burnt)
+			to_chat(user, "<span class='warning'>Repair the plating first!</span>")
+			return
+		var/obj/item/stack/sheet/metal/R = C
+		if (R.get_amount() < 1)
+			to_chat(user, "<span class='warning'>You need one sheet to make a reinforced floor!</span>")
 			return
 		else
 			to_chat(user, "<span class='notice'>You begin reinforcing the floor...</span>")
 			if(do_after(user, 30, target = src))
-				if (R.get_amount() >= 2 && !istype(src, /turf/open/floor/engine))
+				if (R.get_amount() >= 1 && !istype(src, /turf/open/floor/engine))
 					PlaceOnTop(/turf/open/floor/engine, flags = CHANGETURF_INHERIT_AIR)
 					playsound(src, 'sound/items/deconstruct.ogg', 80, TRUE)
-					R.use(2)
+					R.use(1)
 					to_chat(user, "<span class='notice'>You reinforce the floor.</span>")
 				return
-	else if(istype(C, /obj/item/stack/tile))
+	else if(istype(C, /obj/item/stack/tile) && !locate(/obj/structure/lattice/catwalk, src))
 		if(!broken && !burnt)
 			for(var/obj/O in src)
 				for(var/M in O.buckled_mobs)

--- a/code/game/turfs/open/floor/reinf_floor.dm
+++ b/code/game/turfs/open/floor/reinf_floor.dm
@@ -5,7 +5,7 @@
 	icon_state = "engine"
 	thermal_conductivity = 0.025
 	heat_capacity = INFINITY
-	floor_tile = /obj/item/stack/metal
+	floor_tile = /obj/item/stack/sheet/metal
 	footstep = FOOTSTEP_PLATING
 	barefootstep = FOOTSTEP_HARD_BAREFOOT
 	clawfootstep = FOOTSTEP_HARD_CLAW

--- a/code/game/turfs/open/floor/reinf_floor.dm
+++ b/code/game/turfs/open/floor/reinf_floor.dm
@@ -5,7 +5,7 @@
 	icon_state = "engine"
 	thermal_conductivity = 0.025
 	heat_capacity = INFINITY
-	floor_tile = /obj/item/stack/rods
+	floor_tile = /obj/item/stack/metal
 	footstep = FOOTSTEP_PLATING
 	barefootstep = FOOTSTEP_HARD_BAREFOOT
 	clawfootstep = FOOTSTEP_HARD_CLAW
@@ -14,7 +14,7 @@
 
 /turf/open/floor/engine/examine(mob/user)
 	. += ..()
-	. += "<span class='notice'>The reinforcement rods are <b>wrenched</b> firmly in place.</span>"
+	. += "<span class='notice'>The reinforcement sheet is <b>wrenched</b> firmly in place.</span>"
 
 /turf/open/floor/engine/airless
 	initial_gas_mix = AIRLESS_ATMOS
@@ -38,12 +38,12 @@
 
 /turf/open/floor/engine/wrench_act(mob/living/user, obj/item/I)
 	..()
-	to_chat(user, "<span class='notice'>You begin removing rods...</span>")
+	to_chat(user, "<span class='notice'>You begin unsecuring the reinforcement...</span>")
 	if(I.use_tool(src, user, 30, volume=80))
 		if(!istype(src, /turf/open/floor/engine))
 			return TRUE
 		if(floor_tile)
-			new floor_tile(src, 2)
+			new floor_tile(src, 1)
 		ScrapeAway(flags = CHANGETURF_INHERIT_AIR)
 	return TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Creates a variant of catwalks that go over cables, both for mapper and player use. Slightly refactors catwalk code to avoid repeat code.
Catwalk placement behavior directly ported from Beestation, though everything else was a by-hand translation.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
More customization and catwalks that aren't just souped up /turfs/.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Catwalks have received a new variant! Try using rods on plating...
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
