### PR TITLE
Directional HELL

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
+++ b/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
@@ -172,7 +172,7 @@
 /turf/open/floor/plasteel/airless,
 /area/shuttle/caravan/freighter3)
 "aO" = (
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 4;
 	pixel_x = -24
 	},
@@ -271,7 +271,7 @@
 /area/shuttle/caravan/freighter3)
 "bg" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 4;
 	pixel_x = -24
 	},
@@ -768,7 +768,7 @@
 /turf/open/floor/plasteel/dark/airless,
 /area/shuttle/caravan/freighter3)
 "ie" = (
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 8;
 	pixel_x = 24
 	},
@@ -1054,7 +1054,7 @@
 /area/shuttle/caravan/freighter2)
 "ju" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 8;
 	pixel_x = 24
 	},

--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -170,7 +170,7 @@
 /obj/item/stack/sheet/mineral/wood,
 /obj/item/stack/package_wrap,
 /obj/effect/turf_decal/delivery,
-/obj/machinery/airalarm/away{
+/obj/machinery/airalarm/ruin_access{
 	pixel_y = 23
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -381,7 +381,7 @@
 "aZ" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
-/obj/machinery/airalarm/away{
+/obj/machinery/airalarm/ruin_access{
 	pixel_y = 23
 	},
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
@@ -819,7 +819,7 @@
 /area/ruin/space/has_grav/deepstorage/hydroponics)
 "ch" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden,
-/obj/machinery/airalarm/away{
+/obj/machinery/airalarm/ruin_access{
 	dir = 8;
 	pixel_x = 24
 	},
@@ -874,7 +874,7 @@
 /area/ruin/space/has_grav/deepstorage)
 "cm" = (
 /obj/structure/table,
-/obj/machinery/airalarm/away{
+/obj/machinery/airalarm/ruin_access{
 	pixel_y = 23
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -927,7 +927,7 @@
 /area/ruin/space/has_grav/deepstorage)
 "cs" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/machinery/airalarm/away{
+/obj/machinery/airalarm/ruin_access{
 	pixel_y = 23
 	},
 /turf/open/floor/plasteel/freezer,
@@ -1538,7 +1538,7 @@
 /obj/item/radio{
 	pixel_x = 4
 	},
-/obj/machinery/airalarm/away{
+/obj/machinery/airalarm/ruin_access{
 	dir = 8;
 	pixel_x = 24
 	},
@@ -2098,7 +2098,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/machinery/airalarm/away{
+/obj/machinery/airalarm/ruin_access{
 	pixel_y = 23
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -2141,7 +2141,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 4
 	},
-/obj/machinery/airalarm/away{
+/obj/machinery/airalarm/ruin_access{
 	dir = 4;
 	pixel_x = -24
 	},
@@ -2454,7 +2454,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/airalarm/away{
+/obj/machinery/airalarm/ruin_access{
 	dir = 8;
 	pixel_x = 24
 	},
@@ -2772,7 +2772,7 @@
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
 	dir = 4
 	},
-/obj/machinery/airalarm/away{
+/obj/machinery/airalarm/ruin_access{
 	pixel_y = 23
 	},
 /turf/open/floor/light,

--- a/_maps/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation.dmm
@@ -348,7 +348,7 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 8;
 	pixel_x = 24
 	},
@@ -1227,7 +1227,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 4;
 	pixel_x = -23
 	},
@@ -1314,7 +1314,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 8;
 	pixel_x = 24
 	},
@@ -1790,7 +1790,7 @@
 /area/ruin/space/has_grav/ancientstation/rnd)
 "eC" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 8;
 	pixel_x = 24
 	},
@@ -2056,7 +2056,7 @@
 	dir = 8
 	},
 /obj/structure/closet/crate/bin,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 1;
 	pixel_y = -22
 	},
@@ -2522,7 +2522,7 @@
 /area/ruin/space/has_grav/ancientstation/betastorage)
 "gv" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	pixel_y = 23
 	},
 /obj/effect/decal/cleanable/food/egg_smudge,
@@ -2806,7 +2806,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/rnd)
 "hj" = (
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 8;
 	pixel_x = 24
 	},
@@ -2838,7 +2838,7 @@
 /area/ruin/space/has_grav/ancientstation/engi)
 "hn" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 4;
 	pixel_x = -23
 	},
@@ -3544,7 +3544,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 4;
 	pixel_x = -23
 	},
@@ -4037,7 +4037,7 @@
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "jy" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 8;
 	pixel_x = 24
 	},
@@ -4363,7 +4363,7 @@
 /area/ruin/space/has_grav/ancientstation/proto)
 "kj" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	pixel_y = 23
 	},
 /turf/open/floor/plasteel/white,
@@ -4976,7 +4976,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 8;
 	pixel_x = 24
 	},
@@ -4985,7 +4985,7 @@
 "lL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 8;
 	pixel_x = 24
 	},
@@ -5040,7 +5040,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 4;
 	pixel_x = -23
 	},
@@ -5191,7 +5191,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 4;
 	pixel_x = -23
 	},
@@ -5526,7 +5526,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 1;
 	pixel_y = -22
 	},
@@ -5668,7 +5668,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 4;
 	pixel_x = -23
 	},
@@ -6259,7 +6259,7 @@
 /area/ruin/space/has_grav/ancientstation/engi)
 "oz" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 4;
 	pixel_x = -23
 	},
@@ -6438,7 +6438,7 @@
 	icon_state = "medium"
 	},
 /obj/effect/decal/cleanable/glass,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 8;
 	pixel_x = 24
 	},
@@ -6447,7 +6447,7 @@
 	},
 /area/ruin/space/has_grav/ancientstation/betacorridor)
 "oX" = (
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 4;
 	pixel_x = -23
 	},
@@ -7099,7 +7099,7 @@
 /area/ruin/space/has_grav/ancientstation)
 "Iw" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 8;
 	pixel_x = 24
 	},
@@ -7231,7 +7231,7 @@
 /area/ruin/space/has_grav/ancientstation/atmo)
 "LO" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 4;
 	pixel_x = -24
 	},
@@ -7546,7 +7546,7 @@
 "UE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 8;
 	pixel_x = 24
 	},

--- a/_maps/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/RandomZLevels/undergroundoutpost45.dmm
@@ -537,7 +537,7 @@
 /area/awaymission/undergroundoutpost45/central)
 "bt" = (
 /obj/machinery/light/small,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 1;
 	pixel_y = -23
 	},
@@ -1004,7 +1004,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	pixel_y = 23
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -1040,7 +1040,7 @@
 	},
 /area/awaymission/undergroundoutpost45/central)
 "cz" = (
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 4;
 	pixel_x = -23
 	},
@@ -1064,7 +1064,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	pixel_y = 23
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -1184,7 +1184,7 @@
 "cM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5;
-	
+
 	},
 /turf/open/floor/plating{
 	heat_capacity = 1e+006
@@ -1529,7 +1529,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 4;
 	pixel_x = -23
 	},
@@ -1616,7 +1616,7 @@
 	},
 /area/awaymission/undergroundoutpost45/central)
 "dE" = (
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	pixel_y = 23
 	},
 /obj/machinery/light{
@@ -2649,7 +2649,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 8;
 	pixel_x = 23
 	},
@@ -2885,7 +2885,7 @@
 /area/awaymission/undergroundoutpost45/central)
 "fR" = (
 /obj/machinery/light/small,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 1;
 	pixel_y = -23
 	},
@@ -3322,7 +3322,7 @@
 	},
 /area/awaymission/undergroundoutpost45/research)
 "gY" = (
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	pixel_y = 23
 	},
 /obj/machinery/light/small{
@@ -3406,7 +3406,7 @@
 	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "hg" = (
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 8;
 	pixel_x = 23
 	},
@@ -3528,7 +3528,7 @@
 	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "hs" = (
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 8;
 	pixel_x = 23
 	},
@@ -3798,7 +3798,7 @@
 "hU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4;
-	
+
 	},
 /obj/structure/table,
 /obj/item/book/manual/chef_recipes,
@@ -3811,7 +3811,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4;
-	
+
 	},
 /turf/open/floor/plating{
 	heat_capacity = 1e+006
@@ -3859,7 +3859,7 @@
 	},
 /area/awaymission/undergroundoutpost45/gateway)
 "ic" = (
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 8;
 	pixel_x = 23
 	},
@@ -4365,7 +4365,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 4;
 	pixel_x = -23
 	},
@@ -4431,7 +4431,7 @@
 	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "jg" = (
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 4;
 	pixel_x = -23
 	},
@@ -4714,7 +4714,7 @@
 	},
 /area/awaymission/undergroundoutpost45/gateway)
 "jK" = (
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 8;
 	pixel_x = 23
 	},
@@ -5046,7 +5046,7 @@
 	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "ko" = (
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	pixel_y = 23
 	},
 /turf/open/floor/plasteel{
@@ -5284,7 +5284,7 @@
 	},
 /area/awaymission/undergroundoutpost45/gateway)
 "kJ" = (
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	pixel_y = 23
 	},
 /obj/machinery/light/small{
@@ -5394,7 +5394,7 @@
 	},
 /area/awaymission/undergroundoutpost45/research)
 "kT" = (
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	pixel_y = 23
 	},
 /obj/machinery/light/small{
@@ -5594,7 +5594,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 1;
 	pixel_y = -23
 	},
@@ -5666,7 +5666,7 @@
 	},
 /area/awaymission/undergroundoutpost45/gateway)
 "lr" = (
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	pixel_y = 23
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -6265,7 +6265,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	pixel_y = 23
 	},
 /turf/open/floor/carpet{
@@ -6292,7 +6292,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	pixel_y = 23
 	},
 /obj/structure/chair/wood{
@@ -7052,7 +7052,7 @@
 	},
 /area/awaymission/undergroundoutpost45/research)
 "nO" = (
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 4;
 	pixel_x = -23
 	},
@@ -7133,7 +7133,7 @@
 	},
 /area/awaymission/undergroundoutpost45/research)
 "nT" = (
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 4;
 	pixel_x = -23
 	},
@@ -7195,7 +7195,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 4;
 	pixel_x = -23
 	},
@@ -7328,7 +7328,7 @@
 	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "oh" = (
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	pixel_y = 23
 	},
 /obj/structure/disposalpipe/segment{
@@ -7797,7 +7797,7 @@
 	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "oT" = (
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 8;
 	pixel_x = 23
 	},
@@ -8513,7 +8513,7 @@
 /area/awaymission/undergroundoutpost45/research)
 "qp" = (
 /obj/structure/table,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	pixel_y = 23
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -8549,7 +8549,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 8;
 	pixel_x = 23
 	},
@@ -8567,7 +8567,7 @@
 	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "qv" = (
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 8;
 	pixel_x = 23
 	},
@@ -8579,7 +8579,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 4;
 	pixel_x = -23
 	},
@@ -8808,7 +8808,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/airalarm/server{
+/obj/machinery/airalarm/no_alarm{
 	dir = 4;
 	pixel_x = -22
 	},
@@ -9287,7 +9287,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4;
-	
+
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Research Maintenance";
@@ -9445,7 +9445,7 @@
 	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "rT" = (
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	pixel_y = 23
 	},
 /obj/structure/disposalpipe/segment{
@@ -10799,7 +10799,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 5
 	},
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 1;
 	pixel_y = -23
 	},
@@ -11194,7 +11194,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	pixel_y = 23
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -12031,7 +12031,7 @@
 	},
 /area/awaymission/undergroundoutpost45/engineering)
 "wC" = (
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 4;
 	pixel_x = -23
 	},
@@ -12254,7 +12254,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 8;
 	pixel_x = 23
 	},
@@ -12560,7 +12560,7 @@
 /area/awaymission/undergroundoutpost45/mining)
 "xp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 8;
 	pixel_x = 23
 	},
@@ -12887,7 +12887,7 @@
 	},
 /area/awaymission/undergroundoutpost45/mining)
 "xZ" = (
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 4;
 	pixel_x = -23
 	},

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -13743,7 +13743,7 @@
 /area/engine/atmospherics_engine)
 "aEt" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/engine{
+/obj/machinery/airalarm/unlocked/engine{
 	pixel_y = 23
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -111290,7 +111290,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/airalarm/mixingchamber{
+/obj/machinery/airalarm/unlocked/mixingchamber{
 	pixel_y = 24
 	},
 /obj/structure/cable,

--- a/_maps/map_files/HoleStation/holestation.dmm
+++ b/_maps/map_files/HoleStation/holestation.dmm
@@ -4798,6 +4798,7 @@
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/chief)
 "awD" = (
+/obj/effect/mapping_helpers/iannewyear,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "awE" = (
@@ -8183,6 +8184,7 @@
 	},
 /obj/machinery/firealarm/directional/north,
 /obj/effect/turf_decal/siding/wood,
+/obj/effect/mapping_helpers/ianbirthday,
 /turf/open/floor/grass,
 /area/crew_quarters/heads/hop)
 "aMo" = (

--- a/_maps/map_files/HoleStation/holestation.dmm
+++ b/_maps/map_files/HoleStation/holestation.dmm
@@ -131,7 +131,7 @@
 	},
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/siding/thinplating,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/edge,
 /area/security/main)
 "aaA" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
@@ -157,9 +157,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/edge{
+	dir = 8
+	},
 /area/hallway/secondary/entry)
 "aaG" = (
+/obj/machinery/bounty_board/directional/west,
 /turf/open/floor/plasteel/cult,
 /area/library)
 "aaI" = (
@@ -199,6 +202,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow/half,
+/obj/machinery/bounty_board/directional/west,
 /turf/open/floor/plasteel/edge,
 /area/tcommsat/server)
 "aaO" = (
@@ -209,9 +213,7 @@
 /obj/machinery/keycard_auth{
 	pixel_x = -24
 	},
-/obj/machinery/firealarm{
-	pixel_y = 28
-	},
+/obj/machinery/firealarm/directional/north,
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/grass,
 /area/crew_quarters/heads/captain)
@@ -250,9 +252,7 @@
 "abd" = (
 /obj/structure/closet/secure_closet/captains,
 /obj/effect/turf_decal/delivery,
-/obj/machinery/newscaster/security_unit{
-	pixel_y = 32
-	},
+/obj/machinery/newscaster/security_unit/directional/north,
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
@@ -455,9 +455,7 @@
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "acc" = (
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
+/obj/machinery/newscaster/directional/east,
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/library)
@@ -523,10 +521,7 @@
 /obj/machinery/camera/autoname{
 	dir = 9
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -28
-	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/carpet/blue,
 /area/library)
 "acs" = (
@@ -590,9 +585,7 @@
 /area/crew_quarters/heads/hor)
 "acI" = (
 /obj/structure/closet/secure_closet/engineering_chief,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 28
-	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /obj/machinery/camera/autoname{
 	dir = 8
 	},
@@ -712,6 +705,9 @@
 /obj/structure/window/spawner/west,
 /obj/structure/flora/ausbushes/leafybush,
 /obj/structure/flora/ausbushes/ywflowers,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
 /turf/open/floor/grass,
 /area/security/brig)
 "adr" = (
@@ -996,9 +992,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 28
-	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "aeX" = (
@@ -1027,9 +1021,7 @@
 /area/hallway/secondary/entry)
 "afd" = (
 /obj/machinery/washing_machine,
-/obj/item/radio/intercom{
-	pixel_y = 22
-	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/dorms)
 "afh" = (
@@ -1084,9 +1076,7 @@
 "afz" = (
 /obj/structure/bookcase/random/adult,
 /obj/machinery/camera/autoname,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/wood,
 /area/library/lounge)
 "afA" = (
@@ -1100,9 +1090,7 @@
 /obj/structure/closet/secure_closet/bar,
 /obj/item/vending_refill/wardrobe/bar_wardrobe,
 /obj/item/circuitboard/machine/vending,
-/obj/item/radio/intercom{
-	pixel_y = 22
-	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "afD" = (
@@ -1137,10 +1125,7 @@
 /obj/machinery/chem_dispenser/drinks/beer{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "afR" = (
@@ -1184,7 +1169,7 @@
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/suit_storage_unit/security,
 /obj/effect/turf_decal/bot_red,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/whole,
 /area/security/brig)
 "agg" = (
 /turf/open/floor/carpet/blue,
@@ -1214,6 +1199,7 @@
 /area/space/nearstation)
 "ago" = (
 /mob/living/simple_animal/sloth/paperwork,
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/plasteel/mil,
 /area/quartermaster/storage)
 "agp" = (
@@ -1321,10 +1307,7 @@
 /area/engine/engine_smes)
 "agO" = (
 /obj/effect/turf_decal/trimline/blue/corner,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "agQ" = (
@@ -1502,7 +1485,10 @@
 	pixel_y = -3
 	},
 /obj/effect/turf_decal/bot_red,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/whole,
 /area/ai_monitored/security/armory)
 "ahv" = (
 /obj/machinery/computer/communications{
@@ -1514,15 +1500,12 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
 /obj/structure/cable,
+/obj/structure/lattice/catwalk/over,
 /turf/open/floor/plating,
 /area/engine/engine_smes)
 "ahy" = (
@@ -1675,9 +1658,7 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/west,
-/obj/item/radio/intercom{
-	pixel_y = 22
-	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/plasteel/dark/side{
 	dir = 8
 	},
@@ -1706,6 +1687,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/plasteel/edge,
 /area/janitor)
 "aip" = (
@@ -1900,9 +1882,7 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/turf_decal/stripes/line,
-/obj/item/radio/intercom{
-	pixel_y = 22
-	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/plating,
 /area/security/nuke_storage)
 "ajo" = (
@@ -1930,9 +1910,7 @@
 /area/engine/atmos)
 "ajr" = (
 /obj/structure/bed/dogbed/ian,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
+/obj/machinery/newscaster/directional/north,
 /mob/living/simple_animal/pet/dog/corgi/ian,
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/grass,
@@ -1947,7 +1925,7 @@
 "ajt" = (
 /obj/effect/turf_decal/bot_red,
 /obj/structure/closet/secure_closet/security/sec,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/whole,
 /area/security/main)
 "aju" = (
 /obj/machinery/door/airlock/public/glass/incinerator/atmos_exterior,
@@ -2027,6 +2005,7 @@
 "ajO" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/landmark/start/clown,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "ajP" = (
@@ -2130,9 +2109,7 @@
 "akq" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/reagent_dispensers/watertank,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 28
-	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/plasteel/mil,
 /area/hallway/primary/central)
 "akr" = (
@@ -2221,9 +2198,7 @@
 "akA" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/reagent_dispensers/fueltank,
-/obj/item/radio/intercom{
-	pixel_y = 22
-	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/plasteel/mil,
 /area/hallway/primary/central)
 "akB" = (
@@ -2297,6 +2272,9 @@
 "akU" = (
 /obj/structure/closet/secure_closet/hos,
 /obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hos)
 "akV" = (
@@ -2308,10 +2286,10 @@
 /area/engine/storage)
 "akW" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 28
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/plasteel/edge{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/security/main)
 "akX" = (
 /obj/effect/turf_decal/trimline/yellow/line{
@@ -2465,10 +2443,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 1
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -28
-	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "alL" = (
@@ -2572,9 +2547,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 24
-	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/plasteel,
 /area/science/research)
 "amp" = (
@@ -2628,14 +2601,12 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/structure/lattice/catwalk/over,
 /turf/open/floor/plating,
 /area/engine/engine_smes)
 "amy" = (
@@ -2752,7 +2723,10 @@
 	pixel_y = -3
 	},
 /obj/effect/turf_decal/bot_red,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/whole,
 /area/ai_monitored/security/armory)
 "amY" = (
 /obj/machinery/washing_machine,
@@ -3049,9 +3023,7 @@
 "aoj" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/plasteel/cult,
 /area/library)
 "aok" = (
@@ -3329,7 +3301,9 @@
 /area/tcommsat/server)
 "apw" = (
 /obj/structure/cable,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/half{
+	dir = 4
+	},
 /area/ai_monitored/security/armory)
 "apy" = (
 /turf/closed/wall,
@@ -3346,6 +3320,9 @@
 /obj/structure/window/spawner/west,
 /obj/structure/window/spawner/north,
 /obj/structure/flora/ausbushes/lavendergrass,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 9
+	},
 /turf/open/floor/grass,
 /area/security/brig)
 "apC" = (
@@ -3496,9 +3473,7 @@
 /obj/machinery/camera/autoname{
 	dir = 5
 	},
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
+/obj/machinery/newscaster/directional/south,
 /obj/effect/turf_decal/tile/bar/diagonal,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar/atrium)
@@ -3514,10 +3489,8 @@
 /area/chapel/main)
 "aqn" = (
 /obj/structure/table,
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
 /obj/effect/turf_decal/tile/bar/diagonal,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar/atrium)
 "aqo" = (
@@ -3587,6 +3560,7 @@
 /area/crew_quarters/dorms)
 "aqB" = (
 /obj/effect/turf_decal/tile/blue,
+/obj/machinery/bounty_board/directional/east,
 /turf/open/floor/plasteel/white/corner{
 	dir = 4
 	},
@@ -3779,6 +3753,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
 "arD" = (
@@ -3792,7 +3767,9 @@
 "arI" = (
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/half{
+	dir = 4
+	},
 /area/ai_monitored/security/armory)
 "arJ" = (
 /obj/structure/table/glass,
@@ -3842,6 +3819,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/carpet,
 /area/library/lounge)
 "arY" = (
@@ -4011,10 +3989,6 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
@@ -4022,6 +3996,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/structure/lattice/catwalk/over,
 /turf/open/floor/plating,
 /area/engine/engine_smes)
 "asK" = (
@@ -4083,6 +4058,7 @@
 /obj/machinery/atmospherics/pipe/manifold/orange/hidden{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "atc" = (
@@ -4141,13 +4117,17 @@
 /area/maintenance/central/secondary)
 "atu" = (
 /obj/machinery/computer/piratepad_control/civilian,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/half,
 /area/hallway/primary/central)
 "atw" = (
 /turf/open/floor/plasteel/dark/side{
 	dir = 4
 	},
 /area/ai_monitored/turret_protected/ai_upload)
+"atx" = (
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "aty" = (
 /obj/machinery/telecomms/receiver/preset_left/birdstation,
 /turf/open/floor/circuit/green/telecomms,
@@ -4204,6 +4184,9 @@
 /obj/machinery/computer/secure_data{
 	dir = 4
 	},
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 4
+	},
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 4
 	},
@@ -4243,8 +4226,8 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "atY" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "atZ" = (
@@ -4309,9 +4292,7 @@
 /area/hydroponics)
 "auh" = (
 /obj/structure/closet/crate/engineering,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 28
-	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/plasteel/mil/cargo,
@@ -4445,10 +4426,7 @@
 /turf/open/floor/plasteel/dark/edge,
 /area/medical/morgue)
 "auL" = (
-/obj/machinery/airalarm/engine{
-	dir = 4;
-	pixel_x = -24
-	},
+/obj/machinery/airalarm/unlocked/engine/directional/west,
 /turf/open/floor/circuit/green{
 	luminosity = 2
 	},
@@ -4644,10 +4622,7 @@
 "avQ" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/machinery/seed_extractor,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -28
-	},
+/obj/machinery/firealarm/directional/south,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
@@ -4796,10 +4771,7 @@
 /area/space/nearstation)
 "awy" = (
 /obj/effect/turf_decal/loading_area/red,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
+/obj/machinery/firealarm/directional/west,
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 4
 	},
@@ -4820,10 +4792,7 @@
 "awH" = (
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -28
-	},
+/obj/machinery/firealarm/directional/south,
 /obj/structure/railing/corner{
 	dir = 8
 	},
@@ -4999,11 +4968,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "axu" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
 	dir = 4
 	},
+/obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "axv" = (
@@ -5300,9 +5269,7 @@
 /obj/structure/railing/corner,
 /obj/effect/turf_decal/stripes/corner,
 /obj/structure/cable/layer3,
-/obj/machinery/firealarm{
-	pixel_y = 28
-	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/plasteel/mil,
 /area/ai_monitored/turret_protected/ai)
 "ayX" = (
@@ -5550,10 +5517,11 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aAd" = (
-/obj/item/radio/intercom{
-	pixel_y = 22
-	},
+/obj/item/radio/intercom/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
+/obj/effect/turf_decal/siding/red{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aAh" = (
@@ -5840,6 +5808,9 @@
 /area/security/brig)
 "aBz" = (
 /obj/machinery/suit_storage_unit/hos,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hos)
 "aBC" = (
@@ -5930,6 +5901,7 @@
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
+/obj/machinery/bounty_board/directional/south,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "aBX" = (
@@ -6003,6 +5975,7 @@
 "aCv" = (
 /obj/effect/landmark/start/assistant,
 /obj/effect/turf_decal/tile/bar/diagonal,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar/atrium)
 "aCx" = (
@@ -6123,6 +6096,9 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "aDg" = (
+/obj/machinery/computer/arcade/orion_trail{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/security/prison)
 "aDh" = (
@@ -6258,6 +6234,7 @@
 /area/crew_quarters/theatre)
 "aDK" = (
 /obj/structure/table/wood,
+/obj/machinery/bounty_board/directional/east,
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "aDM" = (
@@ -6305,10 +6282,6 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
@@ -6316,6 +6289,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/structure/lattice/catwalk/over,
 /turf/open/floor/plating,
 /area/engine/engine_smes)
 "aEb" = (
@@ -6425,7 +6399,10 @@
 /obj/structure/chair/office{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/whole,
 /area/ai_monitored/security/armory)
 "aEC" = (
 /obj/machinery/door/airlock/command/glass,
@@ -6471,6 +6448,7 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/landmark/start/geneticist,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/plasteel/white,
 /area/science/genetics)
 "aEJ" = (
@@ -6509,11 +6487,8 @@
 /obj/structure/closet/secure_closet/warden,
 /obj/item/storage/lockbox/loyalty,
 /obj/item/grenade/barrier,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/turf/open/floor/plasteel,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/plasteel/whole,
 /area/ai_monitored/security/armory)
 "aES" = (
 /turf/closed/wall,
@@ -6604,6 +6579,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 1
 	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aFp" = (
@@ -6627,7 +6603,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/edge{
+	dir = 8
+	},
 /area/hallway/secondary/entry)
 "aFy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/mix_output{
@@ -6671,9 +6649,7 @@
 /turf/open/floor/plating,
 /area/engine/engine_room)
 "aFE" = (
-/obj/machinery/firealarm{
-	pixel_y = 28
-	},
+/obj/machinery/firealarm/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 4
 	},
@@ -7283,7 +7259,7 @@
 	req_access_txt = "58"
 	},
 /obj/structure/cable,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/half,
 /area/crew_quarters/heads/hos)
 "aIj" = (
 /obj/structure/window/reinforced/spawner,
@@ -7308,7 +7284,7 @@
 /obj/machinery/light,
 /obj/machinery/suit_storage_unit/security,
 /obj/effect/turf_decal/bot_red,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/whole,
 /area/security/brig)
 "aIo" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -7866,7 +7842,10 @@
 	pixel_y = -3
 	},
 /obj/effect/turf_decal/bot_red,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/whole,
 /area/ai_monitored/security/armory)
 "aKR" = (
 /obj/machinery/door/airlock/maintenance,
@@ -7992,7 +7971,10 @@
 /obj/item/storage/toolbox/drone,
 /obj/structure/rack,
 /obj/item/multitool,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/whole,
 /area/ai_monitored/security/armory)
 "aLB" = (
 /obj/machinery/door/airlock/medical{
@@ -8062,7 +8044,9 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/half{
+	dir = 4
+	},
 /area/hallway/secondary/exit)
 "aLT" = (
 /obj/structure/grille,
@@ -8131,9 +8115,7 @@
 /obj/machinery/keycard_auth{
 	pixel_x = 24
 	},
-/obj/machinery/firealarm{
-	pixel_y = 28
-	},
+/obj/machinery/firealarm/directional/north,
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/grass,
 /area/crew_quarters/heads/hop)
@@ -8385,14 +8367,12 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "aNy" = (
-/obj/item/radio/intercom{
-	pixel_x = 25
-	},
 /obj/machinery/computer/med_data,
 /obj/machinery/camera/autoname{
 	dir = 6
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "aNC" = (
@@ -8479,10 +8459,7 @@
 "aNX" = (
 /obj/structure/reagent_dispensers/cooking_oil,
 /obj/effect/turf_decal/delivery,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -28
-	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen/coldroom)
 "aNY" = (
@@ -8603,10 +8580,7 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aOz" = (
@@ -8661,7 +8635,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/whole,
 /area/ai_monitored/security/armory)
 "aOG" = (
 /obj/machinery/chem_dispenser/drinks/beer{
@@ -8713,6 +8690,7 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "aOQ" = (
@@ -8954,13 +8932,14 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "aPT" = (
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aPV" = (
 /obj/structure/ladder,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark/side,
 /area/engine/engine_smes)
 "aPW" = (
@@ -9013,7 +8992,9 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/half{
+	dir = 4
+	},
 /area/hallway/secondary/exit)
 "aQh" = (
 /obj/machinery/door/airlock/medical{
@@ -9199,10 +9180,7 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 5
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -28
-	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "aQR" = (
@@ -9215,6 +9193,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/vehicle/ridden/janicart,
 /obj/item/key/janitor,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/plasteel/edge,
 /area/janitor)
 "aQS" = (
@@ -9421,6 +9400,7 @@
 /obj/structure/railing,
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable/layer3,
+/obj/machinery/bounty_board/directional/east,
 /turf/open/floor/plasteel/mil,
 /area/ai_monitored/turret_protected/ai)
 "aRI" = (
@@ -9527,9 +9507,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
 	dir = 1
 	},
-/obj/item/radio/intercom{
-	pixel_y = 22
-	},
+/obj/item/radio/intercom/directional/north,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
@@ -9611,6 +9589,9 @@
 /area/engine/atmos)
 "aSo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark/corner,
 /area/engine/engine_smes)
 "aSp" = (
@@ -9691,10 +9672,7 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "aSL" = (
@@ -9851,20 +9829,14 @@
 /turf/open/floor/engine/o2,
 /area/engine/atmos)
 "aTu" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -28
-	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aTv" = (
 /turf/closed/wall,
 /area/maintenance/central/secondary)
 "aTw" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/dorms)
 "aTy" = (
@@ -9912,9 +9884,10 @@
 /turf/open/floor/plasteel/mil,
 /area/quartermaster/storage)
 "aTK" = (
-/obj/structure/shuttle/engine/huge,
-/turf/open/transparent/openspace/airless,
-/area/space/nearstation)
+/obj/structure/cable,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/plasteel,
+/area/engine/storage)
 "aTM" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -9979,7 +9952,9 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/half{
+	dir = 4
+	},
 /area/ai_monitored/security/armory)
 "aUj" = (
 /obj/structure/lattice/catwalk,
@@ -10034,10 +10009,15 @@
 /area/engine/gravity_generator)
 "aUs" = (
 /obj/structure/janitorialcart,
+/obj/machinery/bounty_board/directional/east,
 /turf/open/floor/plating,
 /area/janitor)
 "aUv" = (
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/plasteel/dark/side,
 /area/engine/engine_smes)
 "aUw" = (
@@ -10059,9 +10039,7 @@
 /obj/machinery/camera/autoname{
 	dir = 10
 	},
-/obj/item/radio/intercom{
-	pixel_x = -28
-	},
+/obj/item/radio/intercom/directional/west,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
@@ -10407,20 +10385,15 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aWq" = (
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
 /obj/effect/turf_decal/siding/white{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/plasteel/whole,
 /area/science/research)
 "aWr" = (
 /turf/open/transparent/openspace,
@@ -10743,7 +10716,7 @@
 /obj/item/gun/ballistic/shotgun/riot,
 /obj/item/gun/ballistic/shotgun/riot,
 /obj/item/gun/ballistic/shotgun/riot,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/whole,
 /area/ai_monitored/security/armory)
 "aXO" = (
 /turf/open/floor/plating,
@@ -10757,14 +10730,14 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/newscaster/security_unit{
-	pixel_y = 32
-	},
+/obj/machinery/newscaster/security_unit/directional/north,
 /obj/machinery/recharger,
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/edge{
+	dir = 8
+	},
 /area/security/main)
 "aXZ" = (
 /obj/structure/lattice/catwalk,
@@ -10805,6 +10778,9 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark/corner{
 	dir = 8
 	},
@@ -10862,6 +10838,7 @@
 /obj/machinery/computer/cargo{
 	dir = 4
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/wood,
 /area/quartermaster/storage)
 "aYr" = (
@@ -10935,11 +10912,12 @@
 /turf/closed/wall,
 /area/space/nearstation)
 "aYF" = (
-/obj/machinery/newscaster/security_unit{
-	pixel_y = 32
-	},
+/obj/machinery/newscaster/security_unit/directional/north,
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/computer/security{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/red/line{
@@ -11045,7 +11023,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/edge{
+	dir = 8
+	},
 /area/hallway/secondary/entry)
 "aZd" = (
 /obj/structure/window/reinforced/spawner/west,
@@ -11236,6 +11216,7 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/tile/yellow/half,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/plasteel/edge,
 /area/tcommsat/server)
 "aZX" = (
@@ -11329,9 +11310,7 @@
 	dir = 4
 	},
 /obj/machinery/disposal/bin,
-/obj/item/radio/intercom{
-	pixel_y = 24
-	},
+/obj/item/radio/intercom/directional/north,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
@@ -11618,12 +11597,14 @@
 /obj/effect/turf_decal/siding/green{
 	dir = 8
 	},
+/obj/machinery/bounty_board/directional/south,
 /turf/open/floor/plasteel/mil/box,
 /area/quartermaster/warehouse)
 "bWZ" = (
 /obj/machinery/camera/autoname{
 	dir = 10
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "cdT" = (
@@ -11721,7 +11702,9 @@
 /area/crew_quarters/theatre)
 "cvN" = (
 /obj/structure/cable,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/edge{
+	dir = 4
+	},
 /area/security/main)
 "cwX" = (
 /obj/structure/rack,
@@ -11890,6 +11873,7 @@
 "cXT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/structure/railing/corner,
+/obj/effect/turf_decal/siding/white/corner,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "cZh" = (
@@ -11919,10 +11903,7 @@
 /area/medical/psychology)
 "des" = (
 /obj/effect/landmark/start/assistant,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
+/obj/machinery/firealarm/directional/east,
 /obj/effect/turf_decal/tile/bar/diagonal,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar/atrium)
@@ -11957,7 +11938,9 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/half{
+	dir = 4
+	},
 /area/hallway/secondary/exit)
 "dhm" = (
 /obj/structure/disposalpipe/segment{
@@ -12003,9 +11986,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/firealarm{
-	pixel_y = 28
-	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "doJ" = (
@@ -12141,10 +12122,6 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
@@ -12152,6 +12129,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/structure/lattice/catwalk/over,
 /turf/open/floor/plating,
 /area/engine/engine_smes)
 "dTx" = (
@@ -12364,9 +12342,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
 	dir = 1
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 28
-	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -12552,10 +12528,7 @@
 /turf/open/floor/plating,
 /area/lawoffice)
 "eVN" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "eYL" = (
@@ -12682,10 +12655,7 @@
 /area/ai_monitored/turret_protected/ai)
 "flj" = (
 /obj/structure/cable,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "fmX" = (
@@ -12694,6 +12664,10 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
+"fuH" = (
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "fvt" = (
 /obj/effect/landmark/start/assistant,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
@@ -12732,13 +12706,8 @@
 /area/maintenance/port/aft)
 "fxo" = (
 /obj/machinery/stasis,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/obj/item/radio/intercom{
-	dir = 8;
-	pixel_x = 28
-	},
+/obj/item/radio/intercom/directional/east,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/plasteel/mil,
 /area/medical/sleeper)
 "fxQ" = (
@@ -12826,6 +12795,9 @@
 	dir = 10
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/siding/red{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "fDH" = (
@@ -12882,9 +12854,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 28
-	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -12942,12 +12912,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/structure/cable,
+/obj/effect/turf_decal/siding/thinplating,
 /turf/open/floor/plating,
 /area/security/main)
 "fMq" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/plasteel/white,
 /area/hallway/primary/central)
 "fNI" = (
@@ -12996,7 +12968,7 @@
 /turf/open/floor/plating,
 /area/medical)
 "fSz" = (
-/turf/open/transparent/glass,
+/turf/open/floor/plating/foam,
 /area/maintenance/port/aft)
 "fSO" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
@@ -13040,7 +13012,9 @@
 	dir = 6
 	},
 /obj/structure/cable,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/edge{
+	dir = 4
+	},
 /area/security/main)
 "gad" = (
 /obj/effect/turf_decal/delivery,
@@ -13146,7 +13120,9 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/half{
+	dir = 4
+	},
 /area/hallway/secondary/entry)
 "gka" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -13175,10 +13151,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 5
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/plasteel,
 /area/science/lab)
 "gpo" = (
@@ -13259,7 +13232,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/edge{
+	dir = 4
+	},
 /area/security/main)
 "gyn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
@@ -13303,6 +13278,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/plasteel/dark/side{
 	dir = 8
 	},
@@ -13360,10 +13336,7 @@
 /area/maintenance/central/secondary)
 "gLg" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
+/obj/machinery/firealarm/directional/west,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel/dark/half{
 	dir = 4
@@ -13384,6 +13357,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
 /obj/structure/cable,
+/obj/effect/turf_decal/siding/red/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "gSA" = (
@@ -13481,7 +13457,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/structure/cable,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/edge{
+	dir = 8
+	},
 /area/security/main)
 "hlt" = (
 /obj/structure/closet/firecloset/full,
@@ -13527,6 +13505,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"hsL" = (
+/obj/machinery/bounty_board/directional/south,
+/turf/open/floor/plasteel,
+/area/engine/storage)
 "htx" = (
 /obj/machinery/computer/med_data{
 	dir = 4
@@ -13536,16 +13518,18 @@
 	},
 /turf/open/floor/wood,
 /area/security/brig)
+"hvv" = (
+/obj/structure/cable,
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/wood,
+/area/chapel/main)
 "hvQ" = (
 /obj/structure/closet/secure_closet/quartermaster,
 /obj/effect/turf_decal/tile/yellow/whole,
 /obj/effect/turf_decal/siding/yellow{
 	dir = 9
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/plasteel/dark/whole,
 /area/quartermaster/qm)
 "hwG" = (
@@ -13639,7 +13623,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 9
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/edge{
+	dir = 8
+	},
 /area/security/main)
 "hNj" = (
 /obj/effect/turf_decal/stripes/line{
@@ -13684,6 +13670,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hor)
+"hRA" = (
+/obj/machinery/bounty_board/directional/east,
+/turf/open/floor/plasteel,
+/area/security/main)
 "hSv" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -13716,6 +13706,11 @@
 	},
 /turf/open/floor/plasteel/mil,
 /area/hallway/secondary/service)
+"hYN" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/engine,
+/area/engine/engine_room)
 "hZz" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/bottle/epinephrine{
@@ -13885,7 +13880,8 @@
 /obj/effect/landmark/start/warden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/turf/open/floor/plasteel/dark,
+/obj/structure/lattice/catwalk/over,
+/turf/open/floor/plating,
 /area/ai_monitored/security/armory)
 "iws" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -14009,6 +14005,9 @@
 /obj/structure/railing{
 	dir = 4
 	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "iKH" = (
@@ -14059,7 +14058,7 @@
 /area/quartermaster/warehouse)
 "iSi" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/transparent/glass,
+/turf/open/floor/plating/foam,
 /area/maintenance/port/aft)
 "iSt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -14216,6 +14215,12 @@
 /obj/effect/turf_decal/tile/bar/diagonal,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar/atrium)
+"jjD" = (
+/obj/machinery/airalarm/unlocked/engine/directional/east,
+/turf/open/floor/circuit/green{
+	luminosity = 2
+	},
+/area/engine/supermatter)
 "jjI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -14310,10 +14315,7 @@
 /area/maintenance/department/cargo)
 "jrI" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
+/obj/machinery/firealarm/directional/east,
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
@@ -14339,6 +14341,9 @@
 /obj/machinery/vending/wardrobe/det_wardrobe,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 8
+	},
+/obj/effect/turf_decal/siding/red{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -14583,6 +14588,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"jVQ" = (
+/obj/effect/turf_decal/tile/bar/diagonal,
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar/atrium)
 "jWg" = (
 /obj/effect/spawner/structure/window/hollow/middle,
 /turf/open/floor/plating,
@@ -14671,10 +14681,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
@@ -15079,6 +15086,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"ljt" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "lku" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
@@ -15131,10 +15143,7 @@
 /area/maintenance/port/aft)
 "log" = (
 /obj/effect/turf_decal/tile/neutral,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "lsS" = (
@@ -15256,10 +15265,7 @@
 /turf/open/transparent/openspace,
 /area/maintenance/central/secondary)
 "lSu" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/transparent/openspace,
 /area/engine/engine_room)
 "lTd" = (
@@ -15334,9 +15340,7 @@
 /turf/open/floor/plasteel/mil,
 /area/medical/sleeper)
 "mgU" = (
-/obj/machinery/firealarm{
-	pixel_y = 28
-	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/plasteel/white,
 /area/medical)
 "miy" = (
@@ -15358,6 +15362,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/wood,
 /area/lawoffice)
 "mml" = (
@@ -15398,9 +15403,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/obj/item/radio/intercom{
-	pixel_y = 22
-	},
+/obj/item/radio/intercom/directional/north,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -15435,7 +15438,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/whole,
 /area/ai_monitored/security/armory)
 "mzR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
@@ -15514,14 +15520,18 @@
 /obj/effect/landmark/start/prisoner,
 /turf/open/floor/plating,
 /area/security/prison)
+"mQb" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/pinpointer_dispenser{
+	pixel_y = -28
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "mSX" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -28
-	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "mUi" = (
@@ -15534,9 +15544,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 1
 	},
-/obj/item/radio/intercom{
-	pixel_y = -28
-	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "mVC" = (
@@ -15559,10 +15567,7 @@
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -28
-	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/plasteel/white,
 /area/hallway/primary/central)
 "mWQ" = (
@@ -15570,7 +15575,8 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/lattice/catwalk/over,
+/turf/open/floor/plating,
 /area/ai_monitored/security/armory)
 "mXp" = (
 /obj/effect/turf_decal/siding/wood{
@@ -15601,6 +15607,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 6
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -15681,6 +15690,12 @@
 	},
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
+	},
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
@@ -15863,7 +15878,9 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/half{
+	dir = 4
+	},
 /area/hallway/secondary/entry)
 "nMP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
@@ -15888,7 +15905,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/edge{
+	dir = 8
+	},
 /area/security/main)
 "nPL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
@@ -15961,9 +15980,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/obj/item/radio/intercom{
-	pixel_y = 22
-	},
+/obj/item/radio/intercom/directional/north,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
@@ -15987,10 +16004,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -28
-	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/plasteel/mil,
 /area/medical/sleeper)
 "oej" = (
@@ -16027,10 +16041,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "ohD" = (
@@ -16085,12 +16096,22 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"ojM" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/status_display/directional/east,
+/turf/open/floor/plasteel/white/corner{
+	dir = 4
+	},
+/area/hallway/secondary/entry)
 "okZ" = (
 /obj/structure/railing/corner{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 5
+	},
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -16308,7 +16329,7 @@
 /obj/effect/turf_decal/caution/stand_clear{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/whole,
 /area/hallway/secondary/exit)
 "oFy" = (
 /obj/structure/chair/office/light{
@@ -16367,10 +16388,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -28
-	},
+/obj/machinery/firealarm/directional/south,
 /obj/effect/turf_decal/siding/white/corner{
 	dir = 8
 	},
@@ -16389,9 +16407,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/obj/item/radio/intercom{
-	pixel_y = 22
-	},
+/obj/item/radio/intercom/directional/north,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
@@ -16447,10 +16463,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/plasteel/mil,
 /area/quartermaster/miningdock)
 "oVB" = (
@@ -16589,9 +16602,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "pxp" = (
-/obj/item/radio/intercom{
-	pixel_y = 22
-	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/engine/hull/reinforced,
 /area/space/nearstation)
 "pxF" = (
@@ -16601,6 +16612,7 @@
 /area/maintenance/port/aft)
 "pyu" = (
 /obj/machinery/vending/wardrobe/viro_wardrobe,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/plasteel/white/anticorner{
 	dir = 8
 	},
@@ -16612,12 +16624,17 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/structure/cable,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"pAJ" = (
+/obj/effect/turf_decal/bot_red,
+/obj/structure/closet/secure_closet/security/sec,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/plasteel/whole,
+/area/security/main)
 "pBm" = (
 /obj/machinery/power/apc/auto_name/east,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -16902,6 +16919,13 @@
 	},
 /turf/open/transparent/openspace,
 /area/maintenance/starboard/aft/secondary)
+"qAM" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/plating,
+/area/engine/engine_room)
 "qBw" = (
 /obj/machinery/vending/cola/random,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -16935,7 +16959,9 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 10
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/anticorner{
+	dir = 8
+	},
 /area/security/main)
 "qEK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
@@ -17042,15 +17068,17 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/heads/captain)
+"qTz" = (
+/obj/structure/closet/secure_closet/hydroponics,
+/obj/machinery/bounty_board/directional/west,
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "qYf" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -28
-	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/plasteel/white/edge{
 	dir = 8
 	},
@@ -17065,18 +17093,12 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -28
-	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/plating,
 /area/janitor)
 "qZQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "rao" = (
@@ -17126,10 +17148,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/structure/cable,
-/obj/item/radio/intercom{
-	dir = 8;
-	pixel_x = 28
-	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "rlq" = (
@@ -17164,11 +17183,12 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
+"roD" = (
+/obj/effect/turf_decal/siding/white,
+/turf/open/floor/plasteel/half,
+/area/hallway/secondary/entry)
 "rpy" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
+/obj/machinery/firealarm/directional/west,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
@@ -17315,6 +17335,11 @@
 /obj/effect/landmark/start/chemist,
 /turf/open/floor/plasteel/white,
 /area/medical/office)
+"rHe" = (
+/obj/effect/turf_decal/tile/bar/diagonal,
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar/atrium)
 "rHJ" = (
 /obj/structure/cable,
 /obj/structure/window,
@@ -17334,7 +17359,9 @@
 /obj/effect/landmark/blobstart,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/structure/cable,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/edge{
+	dir = 8
+	},
 /area/security/main)
 "rJK" = (
 /obj/machinery/reagentgrinder{
@@ -17372,6 +17399,7 @@
 /obj/structure/railing,
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/plasteel/mil,
 /area/ai_monitored/turret_protected/ai)
 "rOK" = (
@@ -17470,6 +17498,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
@@ -17618,6 +17647,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 5
 	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "squ" = (
@@ -17632,9 +17662,7 @@
 /area/crew_quarters/dorms)
 "srF" = (
 /obj/structure/table/wood/fancy,
-/obj/item/radio/intercom{
-	pixel_y = 22
-	},
+/obj/item/radio/intercom/directional/north,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
@@ -17899,7 +17927,9 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/half{
+	dir = 4
+	},
 /area/hallway/secondary/exit)
 "tdc" = (
 /obj/structure/cable/multilayer/connected,
@@ -17922,7 +17952,7 @@
 /area/bridge)
 "tfH" = (
 /obj/machinery/piratepad/civilian,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/half,
 /area/hallway/primary/central)
 "tfN" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -18124,7 +18154,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/thinplating,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/edge,
 /area/security/main)
 "tAX" = (
 /obj/effect/turf_decal/stripes/line,
@@ -18169,6 +18199,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/maintenance/central/secondary)
+"tEa" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/cable,
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/plasteel,
+/area/engine/storage)
 "tEk" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/structure/cable/layer1,
@@ -18325,6 +18361,14 @@
 /obj/structure/cable,
 /turf/open/transparent/openspace,
 /area/maintenance/central)
+"tSR" = (
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
+"tTd" = (
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "tTz" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -18354,10 +18398,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/structure/cable,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "tYX" = (
@@ -18368,7 +18409,7 @@
 /obj/effect/turf_decal/caution/stand_clear{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/whole,
 /area/hallway/secondary/exit)
 "ucq" = (
 /obj/machinery/atmospherics/pipe/multiz{
@@ -18387,7 +18428,8 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/turf/open/floor/plasteel/dark,
+/obj/structure/lattice/catwalk/over,
+/turf/open/floor/plating,
 /area/ai_monitored/security/armory)
 "ueb" = (
 /obj/effect/turf_decal/stripes/line{
@@ -18482,7 +18524,8 @@
 "uut" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/turf/open/floor/plasteel/dark,
+/obj/structure/lattice/catwalk/over,
+/turf/open/floor/plating,
 /area/ai_monitored/security/armory)
 "uvu" = (
 /obj/structure/lattice/catwalk,
@@ -18552,6 +18595,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/bounty_board/directional/north,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "uAv" = (
@@ -18574,6 +18618,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/siding/red{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "uHJ" = (
@@ -18745,10 +18792,7 @@
 /area/maintenance/central/secondary)
 "vfI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/wood,
 /area/library/lounge)
 "vgI" = (
@@ -18777,10 +18821,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 1
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -28
-	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "vqh" = (
@@ -18807,10 +18848,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 1
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -28
-	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/plasteel/white/edge,
 /area/medical/virology)
 "vwT" = (
@@ -18837,10 +18875,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "vxH" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "vyp" = (
@@ -18924,9 +18959,7 @@
 	},
 /obj/machinery/camera/autoname,
 /obj/effect/turf_decal/tile/neutral,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 28
-	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
 	dir = 1
 	},
@@ -18941,13 +18974,20 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark/whole,
 /area/hallway/secondary/entry)
 "vKT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/storage)
+"vLj" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/bounty_board/directional/south,
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "vMl" = (
 /obj/machinery/computer/mecha{
 	dir = 1
@@ -19097,10 +19137,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/structure/cable,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "wcb" = (
@@ -19290,6 +19327,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/extinguisher_cabinet/directional/south,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "wtJ" = (
@@ -19323,10 +19362,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 6
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "wAU" = (
@@ -19408,10 +19444,7 @@
 /turf/open/floor/plasteel,
 /area/security/nuke_storage)
 "wHJ" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -28
-	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "wIZ" = (
@@ -19450,6 +19483,13 @@
 /obj/structure/cable,
 /turf/open/floor/engine/hull,
 /area/space/nearstation)
+"wMG" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "wNN" = (
 /obj/machinery/computer/crew{
 	dir = 1
@@ -19457,7 +19497,10 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/whole,
 /area/ai_monitored/security/armory)
 "wRn" = (
 /obj/structure/bed,
@@ -19515,6 +19558,13 @@
 	dir = 8
 	},
 /area/science/genetics)
+"wWS" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/status_display/ai/directional/east,
+/turf/open/floor/plasteel/white/corner{
+	dir = 4
+	},
+/area/hallway/secondary/entry)
 "wXs" = (
 /obj/machinery/atmospherics/pipe/multiz{
 	dir = 1
@@ -19867,7 +19917,7 @@
 	},
 /obj/item/clothing/suit/armor/laserproof,
 /obj/effect/spawner/lootdrop/armory_contraband,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/whole,
 /area/ai_monitored/security/armory)
 "xIJ" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -19916,6 +19966,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "xMb" = (
@@ -19958,6 +20011,7 @@
 	dir = 4
 	},
 /obj/machinery/vending/modularpc,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "xTd" = (
@@ -19974,10 +20028,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -28
-	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "xUe" = (
@@ -20052,6 +20103,10 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"yfN" = (
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/kitchen/coldroom)
 "yij" = (
 /obj/structure/chair{
 	dir = 4
@@ -46926,7 +46981,7 @@ aaX
 asd
 asd
 aUZ
-aIV
+yfN
 pOs
 aJM
 abV
@@ -47212,7 +47267,7 @@ aRR
 aqN
 tfN
 abZ
-aEp
+ljt
 atz
 aXb
 aay
@@ -49264,10 +49319,10 @@ amy
 aYP
 aIU
 aIU
-nQT
+aTK
 aBQ
 rlq
-aBQ
+hsL
 aUF
 dPG
 aYj
@@ -49493,7 +49548,7 @@ arh
 iZx
 ayp
 aCG
-aCG
+qTz
 axK
 aGK
 axK
@@ -50302,7 +50357,7 @@ azg
 azg
 tEk
 azg
-azg
+hYN
 azg
 arz
 apZ
@@ -50542,7 +50597,7 @@ aza
 ajP
 iTP
 exL
-vKT
+tEa
 vKT
 vKT
 bLi
@@ -54906,7 +54961,7 @@ qly
 sgi
 dIq
 fvO
-ahK
+wMG
 aQN
 aLk
 aLk
@@ -54927,7 +54982,7 @@ uzw
 abn
 abn
 abn
-abn
+atx
 aDi
 aHA
 aYx
@@ -55405,7 +55460,7 @@ srF
 azk
 aIx
 eNt
-aNU
+hvv
 aNU
 aIu
 dJv
@@ -55938,13 +55993,13 @@ iPG
 aQN
 axN
 adF
-adF
+tTd
 abF
 adF
 ajX
 aOf
 adF
-aTF
+vLj
 aJB
 aAW
 aou
@@ -56199,7 +56254,7 @@ adF
 aBL
 aJy
 aBL
-adF
+tSR
 adF
 aTF
 aJB
@@ -57990,7 +58045,7 @@ uZc
 pXa
 lKI
 kxS
-ahU
+fuH
 aaB
 jhh
 kmU
@@ -110676,7 +110731,7 @@ iKj
 iKj
 iKj
 okZ
-xHB
+mQb
 aoF
 ckA
 ckA
@@ -111180,12 +111235,12 @@ ckA
 aoF
 aJG
 aYS
+ojM
 aqB
-aqB
-aqB
+wWS
 aVZ
 aMR
-ahr
+roD
 aWr
 aWr
 aWr
@@ -111966,7 +112021,7 @@ aIz
 aXU
 qEv
 azW
-ajt
+pAJ
 ayS
 asA
 uGl
@@ -112479,7 +112534,7 @@ akS
 aIz
 asc
 aaz
-azW
+hRA
 ajt
 agS
 aov
@@ -112967,7 +113022,7 @@ tPr
 aUX
 aUX
 aIH
-tPr
+rHe
 aZt
 akS
 akS
@@ -113220,7 +113275,7 @@ aSp
 aSp
 aBf
 aSp
-tPr
+jVQ
 mcU
 mcU
 irD
@@ -117121,7 +117176,7 @@ aCO
 svP
 aPF
 aiQ
-auL
+aOQ
 aTM
 aGW
 aGW
@@ -117635,7 +117690,7 @@ aCO
 adR
 aPF
 aiQ
-aOQ
+jjD
 aTM
 acT
 acT
@@ -117901,7 +117956,7 @@ aiQ
 ayh
 ayh
 ayh
-aFD
+qAM
 aqP
 icv
 aDM
@@ -121262,9 +121317,9 @@ ckA
 ckA
 ckA
 ckA
-eLx
-aOc
-aOc
+ckA
+ckA
+ckA
 ckA
 ckA
 ckA
@@ -121519,10 +121574,10 @@ ckA
 ckA
 ckA
 ckA
-lFz
-lFz
-aOc
-aOc
+ckA
+ckA
+ckA
+ckA
 ckA
 ckA
 ckA
@@ -121776,11 +121831,11 @@ ckA
 ckA
 ckA
 ckA
-lFz
-lFz
-lFz
-eLx
-eLx
+ckA
+ckA
+ckA
+ckA
+ckA
 ckA
 ckA
 ckA
@@ -122033,11 +122088,11 @@ ckA
 ckA
 ckA
 ckA
-lFz
-arS
-lFz
-lFz
-aOc
+ckA
+ckA
+ckA
+ckA
+ckA
 ckA
 ckA
 ckA
@@ -122290,11 +122345,11 @@ ckA
 ckA
 ckA
 ckA
-lFz
-lFz
-lFz
-lFz
-aOc
+ckA
+ckA
+ckA
+ckA
+ckA
 ckA
 ckA
 ckA
@@ -122547,11 +122602,11 @@ ckA
 ckA
 ckA
 ckA
-lFz
-lFz
-aOc
-aOc
-aOc
+ckA
+ckA
+ckA
+ckA
+ckA
 ckA
 ckA
 ckA
@@ -122804,12 +122859,12 @@ ckA
 ckA
 ckA
 ckA
-lFz
-lFz
-aOc
-aAw
-acy
-aTK
+ckA
+ckA
+ckA
+ckA
+ckA
+ckA
 ckA
 ckA
 ckA
@@ -123061,12 +123116,12 @@ ckA
 ckA
 ckA
 ckA
-lFz
-axv
-aOc
-aAw
-acy
-amb
+ckA
+ckA
+ckA
+ckA
+ckA
+ckA
 ckA
 ckA
 ckA
@@ -123318,12 +123373,12 @@ ckA
 ckA
 ckA
 ckA
-lFz
-lFz
-aOc
-aAw
-acy
-amb
+ckA
+ckA
+ckA
+ckA
+ckA
+ckA
 ckA
 ckA
 ckA
@@ -123575,11 +123630,11 @@ ckA
 ckA
 ckA
 ckA
-lFz
-lFz
-aOc
-aOc
-aOc
+ckA
+ckA
+ckA
+ckA
+ckA
 ckA
 ckA
 ckA
@@ -123832,11 +123887,11 @@ ckA
 ckA
 ckA
 ckA
-lFz
-lFz
-lFz
-lFz
-aOc
+ckA
+ckA
+ckA
+ckA
+ckA
 ckA
 ckA
 ckA
@@ -124089,11 +124144,11 @@ ckA
 ckA
 ckA
 ckA
-lFz
-arS
-lFz
-lFz
-aOc
+ckA
+ckA
+ckA
+ckA
+ckA
 ckA
 ckA
 ckA
@@ -124346,11 +124401,11 @@ ckA
 ckA
 ckA
 ckA
-lFz
-lFz
-lFz
-eLx
-eLx
+ckA
+ckA
+ckA
+ckA
+ckA
 ckA
 ckA
 ckA
@@ -124603,10 +124658,10 @@ ckA
 ckA
 ckA
 ckA
-lFz
-lFz
-aOc
-aOc
+ckA
+ckA
+ckA
+ckA
 ckA
 ckA
 ckA
@@ -124860,9 +124915,9 @@ ckA
 ckA
 ckA
 ckA
-eLx
-aOc
-aOc
+ckA
+ckA
+ckA
 ckA
 ckA
 ckA

--- a/_maps/map_files/HoleStation/holestation.dmm
+++ b/_maps/map_files/HoleStation/holestation.dmm
@@ -229,9 +229,7 @@
 "aaW" = (
 /obj/structure/window/spawner/west,
 /obj/structure/displaycase/captain,
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "aaX" = (
@@ -1183,7 +1181,9 @@
 /obj/effect/turf_decal/plaque{
 	icon_state = "L6"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/edge{
+	dir = 4
+	},
 /area/hallway/primary/central)
 "agl" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1629,7 +1629,10 @@
 "aif" = (
 /obj/structure/closet/wardrobe/mixed,
 /obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner,
 /area/hallway/primary/central)
 "aig" = (
 /obj/effect/spawner/lootdrop/maintenance,
@@ -2003,9 +2006,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "ajO" = (
-/obj/effect/turf_decal/tile/red,
 /obj/effect/landmark/start/clown,
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/turf_decal/tile/blue/diagonal{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red/diagonal,
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "ajP" = (
@@ -2057,7 +2063,9 @@
 /turf/open/floor/grass/fakebasalt,
 /area/maintenance/starboard/aft)
 "aka" = (
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/edge{
+	dir = 8
+	},
 /area/bridge)
 "akc" = (
 /obj/structure/lattice/catwalk,
@@ -2502,7 +2510,9 @@
 	req_access_txt = "19";
 	name = "Bridge"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/edge{
+	dir = 8
+	},
 /area/bridge)
 "amb" = (
 /turf/open/transparent/openspace/airless,
@@ -2790,6 +2800,7 @@
 	},
 /obj/structure/railing/corner,
 /obj/structure/cable/layer3,
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/transparent/openspace,
 /area/engine/engine_room)
 "anr" = (
@@ -3758,7 +3769,9 @@
 /area/engine/engine_smes)
 "arD" = (
 /obj/structure/chair/pew/right,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/chapel{
+	dir = 4
+	},
 /area/crew_quarters/theatre)
 "arE" = (
 /obj/structure/cable,
@@ -4117,6 +4130,9 @@
 /area/maintenance/central/secondary)
 "atu" = (
 /obj/machinery/computer/piratepad_control/civilian,
+/obj/effect/turf_decal/tile/brown/half{
+	dir = 1
+	},
 /turf/open/floor/plasteel/half,
 /area/hallway/primary/central)
 "atw" = (
@@ -4190,6 +4206,7 @@
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 4
 	},
+/obj/machinery/status_display/ai/directional/west,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "atQ" = (
@@ -4839,14 +4856,20 @@
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
 "awP" = (
-/obj/structure/musician/piano,
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
-"awR" = (
-/obj/structure/chair/comfy/brown{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/obj/effect/landmark/start/clown,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/cable,
+/obj/machinery/status_display/directional/east,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"awR" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "awT" = (
@@ -4965,7 +4988,12 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
 /area/hallway/primary/central)
 "axu" = (
 /obj/effect/turf_decal/bot,
@@ -5124,7 +5152,12 @@
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
 /area/hallway/primary/central)
 "ayk" = (
 /obj/machinery/airalarm/directional/east,
@@ -5624,7 +5657,9 @@
 "aAL" = (
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/edge{
+	dir = 4
+	},
 /area/bridge)
 "aAM" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
@@ -5760,22 +5795,13 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "aBo" = (
-/obj/structure/table/wood,
-/obj/item/lipstick/random{
-	pixel_x = 6;
-	pixel_y = 6
+/obj/structure/chair{
+	dir = 4
 	},
-/obj/item/lipstick/random{
-	pixel_x = 6;
-	pixel_y = 3
+/obj/effect/turf_decal/tile/blue/diagonal{
+	dir = 4
 	},
-/obj/item/lipstick/random{
-	pixel_x = 6
-	},
-/obj/item/paper_bin{
-	pixel_x = -4;
-	pixel_y = 4
-	},
+/obj/effect/turf_decal/tile/red/diagonal,
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "aBr" = (
@@ -5825,7 +5851,10 @@
 /obj/machinery/camera/autoname{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/dark/diagonal{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/theatre)
 "aBG" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -5843,6 +5872,9 @@
 /obj/machinery/door/airlock/public/glass{
 	req_access_txt = "35";
 	name = "Hydroponics"
+	},
+/obj/effect/turf_decal/siding/green{
+	dir = 8
 	},
 /turf/open/floor/plasteel/mil,
 /area/hydroponics)
@@ -6013,7 +6045,8 @@
 /area/tcommsat/server)
 "aCG" = (
 /obj/structure/closet/secure_closet/hydroponics,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/whole,
 /area/hydroponics)
 "aCK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
@@ -6126,6 +6159,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/plating,
 /area/science/research)
 "aDl" = (
@@ -6155,9 +6189,16 @@
 /obj/machinery/door/airlock/grunge{
 	req_access_txt = "46"
 	},
+/obj/effect/turf_decal/siding/red{
+	dir = 4
+	},
 /turf/open/floor/plasteel/mil,
 /area/crew_quarters/theatre)
 "aDr" = (
+/obj/effect/turf_decal/tile/blue/diagonal{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red/diagonal,
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "aDs" = (
@@ -6226,16 +6267,34 @@
 /turf/open/floor/plasteel/mil,
 /area/hallway/secondary/service)
 "aDJ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/structure/cable,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/dark/diagonal{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/theatre)
 "aDK" = (
 /obj/structure/table/wood,
 /obj/machinery/bounty_board/directional/east,
-/turf/open/floor/plasteel,
+/obj/item/lipstick/random{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/lipstick/random{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/obj/item/lipstick/random{
+	pixel_x = 6
+	},
+/obj/item/paper_bin{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/effect/turf_decal/tile/dark/diagonal{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/theatre)
 "aDM" = (
 /obj/effect/turf_decal/stripes/line{
@@ -6353,6 +6412,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aEt" = (
+/obj/machinery/status_display/directional/south,
 /turf/open/floor/wood,
 /area/security/brig)
 "aEu" = (
@@ -6535,7 +6595,10 @@
 "aFe" = (
 /obj/structure/closet/wardrobe/grey,
 /obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner,
 /area/hallway/primary/central)
 "aFf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
@@ -6813,6 +6876,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "aGl" = (
@@ -6868,6 +6932,7 @@
 /area/engine/supermatter)
 "aGy" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
+/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/mil,
 /area/quartermaster/warehouse)
 "aGA" = (
@@ -7715,10 +7780,11 @@
 /turf/open/floor/plating,
 /area/engine/supermatter)
 "aKt" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/tile/blue/diagonal{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red/diagonal,
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "aKv" = (
@@ -9305,7 +9371,9 @@
 /obj/effect/turf_decal/plaque{
 	icon_state = "L10"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/edge{
+	dir = 8
+	},
 /area/hallway/primary/central)
 "aRk" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
@@ -9336,7 +9404,9 @@
 "aRr" = (
 /obj/structure/chair/pew/left,
 /obj/machinery/camera/autoname,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/chapel{
+	dir = 1
+	},
 /area/crew_quarters/theatre)
 "aRs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -9354,9 +9424,7 @@
 /obj/machinery/camera/autoname{
 	dir = 6
 	},
-/obj/machinery/status_display/supply{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/supply/directional/north,
 /turf/open/floor/plasteel/mil,
 /area/quartermaster/storage)
 "aRy" = (
@@ -9711,7 +9779,9 @@
 "aSR" = (
 /obj/structure/chair/pew/right,
 /obj/machinery/airalarm/directional/north,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/chapel{
+	dir = 4
+	},
 /area/crew_quarters/theatre)
 "aSS" = (
 /obj/structure/cable,
@@ -9830,7 +9900,9 @@
 /area/engine/atmos)
 "aTu" = (
 /obj/machinery/firealarm/directional/south,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/edge{
+	dir = 4
+	},
 /area/hallway/primary/central)
 "aTv" = (
 /turf/closed/wall,
@@ -10098,13 +10170,13 @@
 /turf/open/floor/plating,
 /area/engine/engine_room)
 "aUU" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/tile/dark/diagonal{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white/corner,
 /area/crew_quarters/theatre)
 "aUV" = (
 /obj/machinery/portable_atmospherics/canister/air,
@@ -10797,6 +10869,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/plasteel/dark/corner{
 	dir = 8
 	},
@@ -10828,6 +10901,7 @@
 /obj/effect/turf_decal/siding/yellow{
 	dir = 8
 	},
+/obj/machinery/status_display/ai/directional/east,
 /turf/open/floor/plasteel/dark/whole,
 /area/quartermaster/qm)
 "aYp" = (
@@ -10854,7 +10928,9 @@
 /area/quartermaster/storage)
 "aYt" = (
 /obj/structure/chair/pew/left,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/chapel{
+	dir = 1
+	},
 /area/crew_quarters/theatre)
 "aYv" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -10985,6 +11061,7 @@
 	},
 /obj/structure/closet/secure_closet/atmospherics,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/plasteel/dark/corner{
 	dir = 1
 	},
@@ -11607,6 +11684,11 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"bZl" = (
+/obj/effect/turf_decal/tile/bar/diagonal,
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar/atrium)
 "cdT" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -11691,14 +11773,16 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "cvH" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 5
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/dark/diagonal{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/corner,
 /area/crew_quarters/theatre)
 "cvN" = (
 /obj/structure/cable,
@@ -11916,7 +12000,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/structure/cable,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/half{
+	dir = 4
+	},
 /area/hallway/primary/central)
 "deN" = (
 /obj/machinery/door/airlock/external/glass{
@@ -11963,7 +12049,8 @@
 "dlW" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/machinery/vending/wardrobe/hydro_wardrobe,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/whole,
 /area/hydroponics)
 "dmN" = (
 /obj/structure/closet/secure_closet/psychology,
@@ -12062,6 +12149,13 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/nuke_storage)
+"dIe" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/table/wood,
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
 "dIq" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -12523,6 +12617,20 @@
 /obj/structure/cable,
 /turf/open/floor/mineral/plastitanium/airless,
 /area/space/nearstation)
+"eRp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "eSO" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -12714,7 +12822,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/edge{
+	dir = 4
+	},
 /area/hallway/primary/central)
 "fxV" = (
 /obj/structure/railing{
@@ -12844,6 +12954,16 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"fGO" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/cable/layer1,
+/obj/structure/cable/layer3,
+/obj/machinery/status_display/ai/directional/west,
+/turf/open/transparent/openspace,
+/area/engine/engine_room)
 "fHt" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 8
@@ -12936,7 +13056,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/chapel,
 /area/crew_quarters/theatre)
 "fQC" = (
 /obj/effect/turf_decal/tile/red,
@@ -13240,7 +13360,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/edge{
+	dir = 8
+	},
 /area/hallway/primary/central)
 "gzM" = (
 /turf/open/floor/plating,
@@ -13438,7 +13560,9 @@
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer3,
 /obj/structure/cable,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/half{
+	dir = 4
+	},
 /area/hallway/primary/central)
 "hfz" = (
 /obj/machinery/space_heater,
@@ -14257,9 +14381,7 @@
 /turf/open/floor/carpet,
 /area/library/lounge)
 "jow" = (
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/evac/directional/north,
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
 	},
@@ -14380,6 +14502,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "jwT" = (
@@ -14494,14 +14617,16 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"jId" = (
+/obj/effect/landmark/start/mime,
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
 "jKh" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
@@ -14709,6 +14834,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"kjo" = (
+/obj/machinery/door/airlock/command/glass{
+	req_access_txt = "19";
+	name = "Bridge"
+	},
+/turf/open/floor/plasteel/edge{
+	dir = 4
+	},
+/area/bridge)
 "kjW" = (
 /obj/machinery/power/apc/auto_name/east,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -14771,6 +14905,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/structure/cable,
+/obj/effect/turf_decal/siding/green{
+	dir = 1
+	},
 /turf/open/floor/plasteel/mil,
 /area/hallway/secondary/service)
 "kre" = (
@@ -14935,7 +15072,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/edge{
+	dir = 8
+	},
 /area/hallway/primary/central)
 "kRJ" = (
 /obj/effect/turf_decal/siding/thinplating,
@@ -15164,12 +15303,10 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "lzS" = (
-/obj/machinery/status_display/ai{
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 4
 	},
+/obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "lAP" = (
@@ -15193,20 +15330,38 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "lCG" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/turf_decal/tile/blue/diagonal{
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/red/diagonal,
+/turf/open/floor/plasteel,
+/area/crew_quarters/theatre)
+"lCQ" = (
 /obj/structure/closet/crate/wooden/toy,
+/obj/effect/turf_decal/tile/red/diagonal,
+/obj/effect/turf_decal/tile/blue/diagonal{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "lEj" = (
 /obj/machinery/door/airlock/glass_large{
 	req_access_txt = "46"
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/turf_decal/tile/red/diagonal,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 4
+	},
 /area/crew_quarters/theatre)
 "lFn" = (
 /obj/structure/closet/crate{
@@ -15389,6 +15544,11 @@
 /obj/structure/chair/stool,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"mtA" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/status_display/ai/directional/west,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "mtR" = (
 /obj/machinery/atmospherics/pipe/manifold/orange/visible,
 /turf/open/floor/plating,
@@ -15508,6 +15668,10 @@
 	},
 /turf/open/floor/plasteel/mil,
 /area/quartermaster/storage)
+"mHP" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/hydroponics)
 "mIQ" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/structure/cable,
@@ -15626,6 +15790,11 @@
 	},
 /turf/open/transparent/openspace,
 /area/maintenance/starboard/aft/secondary)
+"nbH" = (
+/obj/structure/cable/layer3,
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/floor/plasteel/mil,
+/area/ai_monitored/turret_protected/ai)
 "nbU" = (
 /turf/closed/wall/r_wall,
 /area/medical/virology)
@@ -15642,6 +15811,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hor)
+"neL" = (
+/obj/effect/turf_decal/bot_red,
+/obj/structure/closet/secure_closet/security/sec,
+/obj/machinery/status_display/ai/directional/south,
+/turf/open/floor/plasteel/whole,
+/area/security/main)
 "neN" = (
 /obj/structure/table,
 /obj/item/storage/box/beakers{
@@ -15667,6 +15842,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/lab)
+"nfh" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/status_display/directional/east,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "nfr" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/landmark/start/janitor,
@@ -15925,6 +16109,14 @@
 /obj/machinery/atmospherics/pipe/multiz,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft/secondary)
+"nUu" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/cable,
+/turf/open/floor/plasteel/half{
+	dir = 4
+	},
+/area/hallway/primary/central)
 "nUD" = (
 /obj/structure/safe/floor,
 /obj/item/clothing/under/syndicate,
@@ -15971,6 +16163,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"nYy" = (
+/obj/structure/cable,
+/obj/machinery/status_display/directional/north,
+/turf/open/floor/plasteel/mil,
+/area/ai_monitored/turret_protected/ai)
 "nYC" = (
 /obj/structure/bed,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -16170,12 +16367,19 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"ouL" = (
-/obj/effect/turf_decal/tile/blue{
+"orJ" = (
+/turf/open/floor/plasteel/edge{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/south,
-/obj/structure/table/wood,
+/area/hallway/primary/central)
+"ouL" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue/diagonal{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red/diagonal,
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "ovj" = (
@@ -16263,6 +16467,7 @@
 /obj/effect/turf_decal/siding/yellow{
 	dir = 8
 	},
+/obj/machinery/status_display/supply/directional/east,
 /turf/open/floor/plasteel/dark/whole,
 /area/quartermaster/qm)
 "oDb" = (
@@ -16431,6 +16636,16 @@
 /obj/structure/cable/layer1,
 /turf/open/floor/plating,
 /area/engine/supermatter)
+"oSR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/turf_decal/tile/red/diagonal,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 4
+	},
+/area/crew_quarters/theatre)
 "oTB" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/disposalpipe/trunk,
@@ -16575,14 +16790,17 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "pse" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/red/diagonal,
 /obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/light,
-/turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "puH" = (
 /obj/machinery/door/airlock/command{
@@ -16705,7 +16923,9 @@
 /obj/item/beacon,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/structure/cable,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/half{
+	dir = 4
+	},
 /area/hallway/primary/central)
 "pTg" = (
 /obj/structure/cable,
@@ -16776,7 +16996,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/chapel{
+	dir = 8
+	},
 /area/crew_quarters/theatre)
 "qcr" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -16791,7 +17013,16 @@
 /area/crew_quarters/heads/captain)
 "qgC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/dark/diagonal{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/corner,
 /area/crew_quarters/theatre)
 "qgQ" = (
 /obj/machinery/power/apc/auto_name/north,
@@ -17071,7 +17302,8 @@
 "qTz" = (
 /obj/structure/closet/secure_closet/hydroponics,
 /obj/machinery/bounty_board/directional/west,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/whole,
 /area/hydroponics)
 "qYf" = (
 /obj/structure/window/reinforced/spawner/west,
@@ -17192,6 +17424,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
+/obj/structure/musician/piano,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "rrj" = (
@@ -17452,10 +17685,9 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "rUD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 9
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 4
 	},
-/obj/effect/landmark/start/mime,
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
 "rUZ" = (
@@ -17584,6 +17816,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"shB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
 "siS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -17600,6 +17836,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 6
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
 	},
 /turf/open/floor/plasteel/mil,
 /area/quartermaster/warehouse)
@@ -17952,6 +18191,9 @@
 /area/bridge)
 "tfH" = (
 /obj/machinery/piratepad/civilian,
+/obj/effect/turf_decal/tile/brown/half{
+	dir = 1
+	},
 /turf/open/floor/plasteel/half,
 /area/hallway/primary/central)
 "tfN" = (
@@ -18100,6 +18342,16 @@
 /obj/structure/cable,
 /turf/open/transparent/openspace,
 /area/maintenance/central)
+"twl" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/chair/comfy/brown{
+	dir = 8
+	},
+/obj/effect/landmark/start/clown,
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
 "twH" = (
 /obj/structure/sign/departments/security,
 /turf/closed/wall,
@@ -18760,6 +19012,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "vdB" = (
@@ -18911,7 +19164,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/structure/cable,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/half{
+	dir = 4
+	},
 /area/bridge)
 "vzO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -19050,14 +19305,23 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/edge{
+	dir = 4
+	},
+/area/hallway/primary/central)
+"vRI" = (
+/turf/open/floor/plasteel/edge{
+	dir = 8
+	},
 /area/hallway/primary/central)
 "vTK" = (
 /obj/structure/chair/pew/left,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/chapel{
+	dir = 8
+	},
 /area/crew_quarters/theatre)
 "vUC" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
@@ -19228,9 +19492,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/landmark/start/assistant,
-/obj/machinery/status_display/supply{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/supply/directional/north,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "whi" = (
@@ -19308,16 +19570,16 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "woy" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/effect/landmark/start/mime,
 /obj/machinery/power/apc/auto_name/north,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 8
 	},
 /obj/structure/cable,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/dark/diagonal{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/theatre)
 "wsR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
@@ -19358,6 +19620,10 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"wxG" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/crew_quarters/theatre)
 "wzr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 6
@@ -19631,6 +19897,11 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/nuke_storage)
+"xdj" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/status_display/directional/west,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "xfq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -19698,7 +19969,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/chapel,
 /area/crew_quarters/theatre)
 "xmo" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -20127,7 +20398,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/half{
+	dir = 4
+	},
 /area/hallway/primary/central)
 "ykn" = (
 /obj/machinery/space_heater,
@@ -48535,7 +48808,7 @@ aWx
 aWx
 iZT
 aSd
-fTZ
+eRp
 aCj
 azO
 nOC
@@ -48784,7 +49057,7 @@ miy
 amD
 tOS
 arw
-amD
+xdj
 axr
 aQw
 eMy
@@ -50834,7 +51107,7 @@ aQL
 crP
 azR
 xUo
-aoU
+mHP
 anZ
 anZ
 anZ
@@ -51091,7 +51364,7 @@ aoU
 dlW
 arh
 aYr
-aoU
+mHP
 anZ
 anZ
 anZ
@@ -51594,12 +51867,12 @@ oLT
 aaC
 aij
 aAL
-alZ
+kjo
 vQV
 agk
 fxQ
-aCj
-aCj
+orJ
+orJ
 aTu
 ark
 aYJ
@@ -51856,8 +52129,8 @@ hfg
 dew
 yjt
 pQy
-hOT
-hOT
+nUu
+nUu
 knZ
 wWu
 rAU
@@ -52112,9 +52385,9 @@ alZ
 kPo
 aRi
 gyn
-aCj
-aCj
-aCj
+vRI
+vRI
+vRI
 ark
 aEi
 aDI
@@ -52630,10 +52903,10 @@ apy
 apy
 apy
 apy
-apy
+lCQ
 aDr
 aBo
-apy
+wxG
 anZ
 anZ
 anZ
@@ -52886,11 +53159,11 @@ apy
 aRr
 vTK
 rpy
-awP
+apy
 apy
 ajO
 ouL
-apy
+wxG
 anZ
 anZ
 anZ
@@ -53142,8 +53415,8 @@ ahK
 apy
 aSR
 fQg
-mXp
-awR
+twl
+avc
 apy
 aKt
 lCG
@@ -53399,10 +53672,10 @@ lBP
 ksG
 bJL
 rUD
-mXp
-avc
+awR
+shB
 lEj
-aKt
+oSR
 pse
 aFp
 aHj
@@ -53914,7 +54187,7 @@ apy
 aYt
 qbM
 mXp
-avc
+jId
 apy
 woy
 aDJ
@@ -54170,7 +54443,7 @@ aBR
 apy
 arD
 xis
-mXp
+dIe
 axk
 apy
 aBF
@@ -54684,7 +54957,7 @@ xhh
 amD
 aim
 amD
-amD
+mtA
 amD
 aqs
 log
@@ -54941,7 +55214,7 @@ sXf
 fSO
 gWq
 axz
-axz
+awP
 kbu
 axz
 axz
@@ -54952,7 +55225,7 @@ fis
 pAt
 axz
 sdW
-iwt
+nfh
 hNN
 edh
 kEw
@@ -112535,7 +112808,7 @@ aIz
 asc
 aaz
 hRA
-ajt
+neL
 agS
 aov
 jtI
@@ -113018,7 +113291,7 @@ ckA
 aSp
 aSp
 aSp
-tPr
+bZl
 aUX
 aUX
 aIH
@@ -116866,7 +117139,7 @@ ckA
 ckA
 axx
 axx
-iSz
+nbH
 aRE
 xvT
 xvT
@@ -117894,7 +118167,7 @@ ckA
 ckA
 axx
 axx
-reu
+nYy
 rOE
 xvT
 xvT
@@ -118719,7 +118992,7 @@ aZp
 aBl
 aZX
 aHO
-aUj
+fGO
 aUj
 aUj
 aXZ

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -33345,7 +33345,7 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/science/server)
 "bAz" = (
-/obj/machinery/airalarm/server{
+/obj/machinery/airalarm/no_alarm{
 	dir = 4;
 	pixel_x = -22
 	},
@@ -44575,7 +44575,7 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 8;
 	pixel_x = 24
 	},
@@ -46577,7 +46577,7 @@
 	dir = 1;
 	name = "Gas to Filter"
 	},
-/obj/machinery/airalarm/engine{
+/obj/machinery/airalarm/unlocked/engine{
 	dir = 4;
 	pixel_x = -23
 	},
@@ -51195,7 +51195,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/airalarm/mixingchamber{
+/obj/machinery/airalarm/unlocked/mixingchamber{
 	dir = 4;
 	pixel_x = -24
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -380,7 +380,7 @@
 	pixel_y = 5
 	},
 /obj/item/reagent_containers/dropper,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 4;
 	pixel_x = -24
 	},
@@ -38356,7 +38356,7 @@
 /turf/open/floor/engine/n2o,
 /area/engine/atmos)
 "bMo" = (
-/obj/machinery/airalarm/server{
+/obj/machinery/airalarm/no_alarm{
 	dir = 4;
 	pixel_x = -22
 	},
@@ -51093,7 +51093,7 @@
 	dir = 8;
 	network = list("ss13","engine")
 	},
-/obj/machinery/airalarm/engine{
+/obj/machinery/airalarm/unlocked/engine{
 	dir = 8;
 	pixel_x = 24
 	},
@@ -54511,7 +54511,7 @@
 	},
 /area/science/mixing)
 "czH" = (
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 8;
 	pixel_x = 24
 	},
@@ -55795,7 +55795,7 @@
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
 "cDm" = (
-/obj/machinery/airalarm/mixingchamber{
+/obj/machinery/airalarm/unlocked/mixingchamber{
 	dir = 4;
 	pixel_x = -24
 	},
@@ -57712,7 +57712,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/airalarm/server{
+/obj/machinery/airalarm/no_alarm{
 	dir = 8;
 	pixel_x = 22
 	},

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -33702,7 +33702,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/machinery/airalarm/mixingchamber{
+/obj/machinery/airalarm/unlocked/mixingchamber{
 	dir = 1;
 	pixel_y = -24
 	},
@@ -52119,7 +52119,7 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
-/obj/machinery/airalarm/engine{
+/obj/machinery/airalarm/unlocked/engine{
 	pixel_y = 24
 	},
 /turf/open/floor/engine,

--- a/_maps/map_files/SpiderNest/SpiderNest.dmm
+++ b/_maps/map_files/SpiderNest/SpiderNest.dmm
@@ -108,9 +108,7 @@
 	dir = 1;
 	pixel_y = -1
 	},
-/obj/item/radio/intercom{
-	pixel_y = 30
-	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aav" = (
@@ -1015,11 +1013,8 @@
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "adl" = (
-/obj/machinery/airalarm/no_alarm{
-	dir = 8;
-	pixel_x = 28
-	},
 /obj/structure/cable,
+/obj/machinery/airalarm/no_alarm/directional/east,
 /turf/open/floor/plasteel/telecomms,
 /area/tcommsat/server)
 "adm" = (
@@ -1178,9 +1173,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "adK" = (
-/obj/machinery/firealarm{
-	pixel_y = -28
-	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "adL" = (
@@ -2202,10 +2195,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/directional/east,
 /obj/machinery/camera{
 	c_tag = "Supermatter Foyer";
 	dir = 8;
@@ -5305,10 +5295,7 @@
 /obj/machinery/atmospherics/pipe/manifold/green/visible{
 	dir = 4
 	},
-/obj/machinery/airalarm/unlocked/engine{
-	dir = 4;
-	pixel_x = -24
-	},
+/obj/machinery/airalarm/unlocked/engine/directional/west,
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "aoq" = (
@@ -6284,9 +6271,7 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "aqY" = (
-/obj/item/radio/intercom{
-	pixel_y = 32
-	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "aqZ" = (
@@ -6501,9 +6486,7 @@
 /area/engine/storage)
 "arA" = (
 /obj/structure/reagent_dispensers/fueltank,
-/obj/item/radio/intercom{
-	pixel_x = -25
-	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "arB" = (
@@ -6662,10 +6645,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/directional/east,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light/dim{
@@ -8196,9 +8176,7 @@
 	dir = 5
 	},
 /obj/machinery/computer/secure_data,
-/obj/item/radio/intercom{
-	pixel_y = 32
-	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "avr" = (
@@ -8489,9 +8467,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/item/radio/intercom{
-	pixel_y = 32
-	},
+/obj/item/radio/intercom/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -9257,10 +9233,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "ayo" = (
@@ -9504,18 +9477,14 @@
 "ayM" = (
 /obj/structure/rack,
 /obj/machinery/airalarm/directional/east,
-/obj/item/radio/intercom{
-	pixel_y = 32
-	},
+/obj/item/radio/intercom/directional/north,
 /obj/effect/spawner/lootdrop/department/engineering,
 /obj/item/stock_parts/capacitor,
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
 "ayN" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer1,
-/obj/item/radio/intercom{
-	pixel_y = 32
-	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "ayO" = (
@@ -9536,13 +9505,8 @@
 /obj/machinery/computer/camera_advanced{
 	networks = list("eng","incin")
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/item/radio/intercom{
-	pixel_y = 32
-	},
+/obj/machinery/firealarm/directional/west,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ayR" = (
@@ -9877,9 +9841,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
 	},
-/obj/item/radio/intercom{
-	pixel_y = 32
-	},
+/obj/item/radio/intercom/directional/north,
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
@@ -10254,10 +10216,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
 	c_tag = "Engine - Mixing Room";
@@ -12800,9 +12759,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/item/radio/intercom{
-	pixel_x = 28
-	},
+/obj/item/radio/intercom/directional/east,
 /obj/machinery/computer/security{
 	dir = 8
 	},
@@ -13300,9 +13257,7 @@
 /obj/machinery/light/dim{
 	dir = 4
 	},
-/obj/item/radio/intercom{
-	pixel_x = 28
-	},
+/obj/item/radio/intercom/directional/east,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -13430,9 +13385,7 @@
 /obj/item/reagent_containers/glass/beaker,
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/item/reagent_containers/dropper,
-/obj/item/radio/intercom{
-	pixel_y = 32
-	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "aIE" = (
@@ -13799,9 +13752,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/patients_rooms)
 "aJz" = (
-/obj/machinery/status_display/ai{
-	pixel_x = 32
-	},
+/obj/machinery/status_display/ai/directional/east,
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -14689,9 +14640,7 @@
 /obj/machinery/computer/card{
 	dir = 4
 	},
-/obj/item/radio/intercom{
-	pixel_y = 28
-	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "aLG" = (
@@ -14795,9 +14744,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/obj/item/radio/intercom{
-	pixel_y = 30
-	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/plasteel/white,
 /area/medical/pharmacy)
 "aLR" = (
@@ -15583,9 +15530,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/item/radio/intercom{
-	pixel_y = 23
-	},
+/obj/item/radio/intercom/directional/north,
 /obj/machinery/photocopier,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -15900,9 +15845,7 @@
 /obj/machinery/computer/bounty{
 	dir = 8
 	},
-/obj/item/radio/intercom{
-	pixel_y = 32
-	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "aOz" = (
@@ -18677,9 +18620,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/firealarm{
-	pixel_x = 28
-	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "aVa" = (
@@ -19073,9 +19014,7 @@
 	},
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/box,
-/obj/item/radio/intercom{
-	pixel_y = -28
-	},
+/obj/item/radio/intercom/directional/south,
 /obj/item/seeds/potato{
 	pixel_x = 27;
 	pixel_y = 4
@@ -21309,9 +21248,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/status_display/ai{
-	pixel_y = 30
-	},
+/obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "bbI" = (
@@ -21356,9 +21293,7 @@
 	dir = 6
 	},
 /obj/structure/table/glass,
-/obj/item/radio/intercom{
-	pixel_x = 32
-	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "bbN" = (
@@ -21580,10 +21515,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bcm" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -21688,9 +21620,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "bcB" = (
-/obj/machinery/firealarm{
-	pixel_y = 28
-	},
+/obj/machinery/firealarm/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -21916,9 +21846,7 @@
 /obj/structure/table/glass,
 /obj/machinery/computer/med_data/laptop,
 /obj/item/radio/headset/headset_medsci,
-/obj/item/radio/intercom{
-	pixel_x = 30
-	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/plasteel/white,
 /area/science/genetics)
 "bdc" = (
@@ -22360,9 +22288,7 @@
 /area/science/xenobiology)
 "ben" = (
 /obj/machinery/chem_master,
-/obj/item/radio/intercom{
-	pixel_y = 32
-	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "beo" = (
@@ -23143,9 +23069,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "bgc" = (
-/obj/item/radio/intercom{
-	pixel_x = 32
-	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/plasteel/sepia,
 /area/engine/gravity_generator)
 "bgd" = (
@@ -23335,9 +23259,7 @@
 /area/medical/psychology)
 "bgH" = (
 /obj/structure/filingcabinet/filingcabinet,
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/wood,
 /area/medical/psychology)
 "bgI" = (
@@ -25702,9 +25624,7 @@
 "bmt" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
-/obj/item/radio/intercom{
-	pixel_y = 28
-	},
+/obj/item/radio/intercom/directional/north,
 /obj/item/restraints/handcuffs/cable,
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -27483,10 +27403,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bHV" = (
@@ -27872,7 +27789,7 @@
 	dir = 4
 	},
 /obj/machinery/meter,
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/sepia,
 /area/maintenance/disposal)
 "cqD" = (
 /obj/structure/table/reinforced,
@@ -27999,7 +27916,7 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/visible{
 	dir = 4
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/sepia,
 /area/maintenance/disposal)
 "cCK" = (
 /obj/machinery/power/apc/auto_name/west,
@@ -28216,10 +28133,7 @@
 /turf/open/floor/wood,
 /area/hallway/secondary/command)
 "cTE" = (
-/obj/machinery/status_display/ai{
-	dir = 4;
-	pixel_x = -32
-	},
+/obj/machinery/status_display/ai/directional/west,
 /obj/machinery/computer/crew{
 	dir = 4
 	},
@@ -28390,7 +28304,7 @@
 /obj/machinery/atmospherics/pipe/simple/orange/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/sepia,
 /area/maintenance/disposal)
 "diR" = (
 /obj/structure/lattice,
@@ -28458,7 +28372,7 @@
 /obj/machinery/atmospherics/components/trinary/mixer{
 	dir = 8
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/sepia,
 /area/maintenance/disposal)
 "dpX" = (
 /obj/effect/turf_decal/bot,
@@ -28597,9 +28511,7 @@
 "dHr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/item/radio/intercom{
-	pixel_x = 32
-	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/medical)
 "dHz" = (
@@ -28676,7 +28588,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/sepia,
 /area/maintenance/disposal)
 "dOV" = (
 /obj/structure/table/greyscale,
@@ -28710,7 +28622,7 @@
 "dQD" = (
 /obj/effect/turf_decal/box/red,
 /obj/random/equipment/atmospherics/canister/dangerous,
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/sepia,
 /area/maintenance/disposal)
 "dSc" = (
 /obj/structure/cable,
@@ -28826,10 +28738,7 @@
 /turf/open/floor/carpet/red,
 /area/crew_quarters/theatre)
 "ecS" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "eet" = (
@@ -28857,9 +28766,7 @@
 /turf/open/floor/plasteel/telecomms,
 /area/tcommsat/server)
 "ehh" = (
-/obj/machinery/status_display/ai{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "ehH" = (
@@ -29037,10 +28944,7 @@
 /turf/open/floor/plasteel,
 /area/science/storage)
 "exQ" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "eyS" = (
@@ -29071,9 +28975,7 @@
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/west,
-/obj/item/radio/intercom{
-	pixel_y = 32
-	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/plasteel/dark,
 /area/science/server)
 "eBt" = (
@@ -29452,10 +29354,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "fmG" = (
@@ -29858,10 +29757,7 @@
 	pixel_x = 5;
 	pixel_y = 2
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "fPY" = (
@@ -30011,9 +29907,7 @@
 /turf/open/floor/circuit/red/anim,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "giq" = (
-/obj/item/radio/intercom{
-	pixel_x = 32
-	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "gjq" = (
@@ -30097,7 +29991,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/sepia,
 /area/maintenance/disposal)
 "goa" = (
 /obj/effect/decal/cleanable/dirt,
@@ -30359,9 +30253,7 @@
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "gLI" = (
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/evac/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
@@ -30380,7 +30272,7 @@
 	name = "Disposals Storage";
 	req_one_access_txt = "ACCESS_ATMOSPHERICS;ACCESS_TOXINS_STORAGE"
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/sepia,
 /area/maintenance/disposal)
 "gPq" = (
 /turf/closed/wall/retro,
@@ -30484,9 +30376,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "gYx" = (
-/obj/machinery/firealarm{
-	pixel_y = 28
-	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "gYG" = (
@@ -30977,10 +30867,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/bin,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "ieO" = (
@@ -31026,9 +30913,7 @@
 	dir = 1;
 	pixel_y = -1
 	},
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/evac/directional/north,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -31198,7 +31083,7 @@
 /obj/machinery/atmospherics/pipe/simple/orange/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/sepia,
 /area/maintenance/disposal)
 "isU" = (
 /obj/machinery/camera{
@@ -31209,7 +31094,7 @@
 /area/hallway/secondary/entry)
 "itn" = (
 /obj/machinery/light/small,
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/sepia,
 /area/maintenance/disposal)
 "ivh" = (
 /obj/effect/turf_decal/stripes/red{
@@ -31388,7 +31273,7 @@
 	dir = 4
 	},
 /obj/machinery/meter,
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/sepia,
 /area/maintenance/disposal)
 "iPz" = (
 /obj/structure/cable,
@@ -31488,7 +31373,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden/layer5{
 	dir = 10
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/sepia,
 /area/maintenance/disposal)
 "jbC" = (
 /obj/structure/cable,
@@ -32085,9 +31970,7 @@
 	dir = 6
 	},
 /obj/structure/cable,
-/obj/item/radio/intercom{
-	pixel_y = 28
-	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/engine,
 /area/science/robotics/mechbay)
 "khu" = (
@@ -32108,7 +31991,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/sepia,
 /area/maintenance/disposal)
 "kiH" = (
 /obj/machinery/camera/preset/toxins{
@@ -32441,7 +32324,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/sepia,
 /area/maintenance/disposal)
 "kWx" = (
 /obj/structure/lattice,
@@ -32700,9 +32583,7 @@
 /turf/open/floor/plasteel,
 /area/engine/storage)
 "lCV" = (
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/evac/directional/west,
 /obj/machinery/computer/security{
 	dir = 4
 	},
@@ -33168,7 +33049,7 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/sepia,
 /area/maintenance/disposal)
 "msf" = (
 /obj/structure/extinguisher_cabinet{
@@ -33201,7 +33082,7 @@
 /obj/machinery/atmospherics/pipe/simple/orange/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/sepia,
 /area/maintenance/disposal)
 "mtd" = (
 /obj/effect/turf_decal/bot,
@@ -33314,9 +33195,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "mCO" = (
-/obj/machinery/status_display/ai{
-	pixel_x = 32
-	},
+/obj/machinery/status_display/ai/directional/east,
 /obj/structure/showcase/cyborg/old{
 	dir = 8;
 	pixel_x = 9;
@@ -33377,15 +33256,13 @@
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/sepia,
 /area/maintenance/disposal)
 "mJT" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
 	},
-/obj/machinery/status_display/ai{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/ai/directional/north,
 /obj/machinery/flasher{
 	id = "AI";
 	pixel_x = -24;
@@ -33460,7 +33337,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/sepia,
 /area/maintenance/disposal)
 "mQQ" = (
 /obj/structure/disposalpipe/segment,
@@ -33998,9 +33875,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/theatre/stage)
 "ogX" = (
-/obj/machinery/firealarm{
-	pixel_x = 28
-	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "oip" = (
@@ -34353,7 +34228,7 @@
 	dir = 8;
 	network = list("ss13","incin")
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/sepia,
 /area/maintenance/disposal)
 "oLu" = (
 /turf/closed/wall/retro,
@@ -34377,10 +34252,7 @@
 /turf/open/floor/mech_bay_recharge_floor,
 /area/science/robotics/mechbay)
 "oMX" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/directional/east,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 32
 	},
@@ -34496,7 +34368,7 @@
 "oZw" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/computer/atmos_control/incinerator,
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/sepia,
 /area/maintenance/disposal)
 "paq" = (
 /obj/machinery/computer/security/mining{
@@ -34575,7 +34447,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/sepia,
 /area/maintenance/disposal)
 "pgw" = (
 /obj/machinery/camera{
@@ -34616,15 +34488,13 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 10
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/sepia,
 /area/maintenance/disposal)
 "plh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	pixel_y = 28
-	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "pll" = (
@@ -34759,7 +34629,7 @@
 	dir = 1;
 	name = "Connector to Mix"
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/sepia,
 /area/maintenance/disposal)
 "pCx" = (
 /obj/effect/turf_decal/stripes/line,
@@ -34888,7 +34758,7 @@
 /area/hallway/primary/central)
 "pOq" = (
 /obj/machinery/light/dim,
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/sepia,
 /area/maintenance/disposal)
 "pOs" = (
 /obj/structure/sign/departments/tcomms{
@@ -35414,7 +35284,7 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/sepia,
 /area/maintenance/disposal)
 "qOF" = (
 /obj/effect/decal/cleanable/dirt,
@@ -35825,9 +35695,7 @@
 	dir = 1;
 	pixel_y = -1
 	},
-/obj/item/radio/intercom{
-	pixel_y = 28
-	},
+/obj/item/radio/intercom/directional/north,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
@@ -35850,7 +35718,7 @@
 /area/science/mixing)
 "rQb" = (
 /obj/effect/turf_decal/box/red,
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/sepia,
 /area/maintenance/disposal)
 "rQe" = (
 /obj/machinery/light/small{
@@ -35928,7 +35796,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/sepia,
 /area/maintenance/disposal)
 "scm" = (
 /obj/structure/table/reinforced,
@@ -36799,10 +36667,7 @@
 /turf/open/floor/plating,
 /area/science/robotics/lab)
 "tJw" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/carpet/red,
 /area/crew_quarters/bar)
 "tJG" = (
@@ -37175,10 +37040,7 @@
 /turf/closed/wall,
 /area/security/detectives_office)
 "uqX" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/cafeteria)
 "urC" = (
@@ -37260,7 +37122,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/sepia,
 /area/maintenance/disposal)
 "uCC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
@@ -37288,7 +37150,7 @@
 "uDl" = (
 /obj/effect/turf_decal/box/red,
 /obj/machinery/portable_atmospherics/canister/hydrogen,
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/sepia,
 /area/maintenance/disposal)
 "uDF" = (
 /obj/structure/table/reinforced,
@@ -37490,7 +37352,7 @@
 /area/science/robotics/mechbay)
 "uZW" = (
 /obj/effect/turf_decal/box,
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/sepia,
 /area/maintenance/disposal)
 "vak" = (
 /obj/effect/turf_decal/stripes/line{
@@ -37586,9 +37448,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "vpx" = (
-/obj/machinery/status_display/ai{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/ai/directional/west,
 /obj/structure/showcase/cyborg/old{
 	dir = 4;
 	pixel_x = -9;
@@ -37733,7 +37593,7 @@
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "vEa" = (
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/sepia,
 /area/maintenance/disposal)
 "vEW" = (
 /obj/machinery/light/dim{
@@ -38005,7 +37865,7 @@
 	dir = 1;
 	pixel_y = -1
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/sepia,
 /area/maintenance/disposal)
 "wlv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -38048,7 +37908,7 @@
 "wnc" = (
 /obj/effect/turf_decal/box,
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/sepia,
 /area/maintenance/disposal)
 "wnU" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -38070,7 +37930,7 @@
 	c_tag = "Incinerator Storage";
 	network = list("ss13","incin")
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/sepia,
 /area/maintenance/disposal)
 "wqE" = (
 /obj/machinery/ai_slipper{
@@ -38100,10 +37960,7 @@
 	c_tag = "Hydroponics";
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "wsP" = (
@@ -38205,13 +38062,11 @@
 /area/maintenance/disposal)
 "wGN" = (
 /obj/structure/table/wood,
-/obj/machinery/firealarm{
-	pixel_x = -32
-	},
 /obj/item/phone,
 /obj/machinery/light/dim{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "wIc" = (
@@ -38258,7 +38113,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/sepia,
 /area/maintenance/disposal)
 "wKb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -38384,7 +38239,7 @@
 /area/medical/cryo)
 "wVi" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/sepia,
 /area/maintenance/disposal)
 "wVy" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -38427,7 +38282,7 @@
 	node1_concentration = 1;
 	node2_concentration = 0
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/sepia,
 /area/maintenance/disposal)
 "wZj" = (
 /obj/structure/table/greyscale,
@@ -38581,7 +38436,7 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 6
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/sepia,
 /area/maintenance/disposal)
 "xoH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
@@ -38727,10 +38582,7 @@
 /area/quartermaster/storage)
 "xIP" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "xJb" = (
@@ -38752,9 +38604,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/theatre/stage)
 "xKZ" = (
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "xLz" = (
@@ -38972,9 +38822,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "yjE" = (
-/obj/machinery/status_display/ai{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 
@@ -89915,7 +89763,7 @@ aya
 aya
 aya
 ieT
-utD
+api
 arC
 jvT
 arl

--- a/_maps/map_files/SpiderNest/SpiderNest.dmm
+++ b/_maps/map_files/SpiderNest/SpiderNest.dmm
@@ -1015,7 +1015,7 @@
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "adl" = (
-/obj/machinery/airalarm/server{
+/obj/machinery/airalarm/no_alarm{
 	dir = 8;
 	pixel_x = 28
 	},
@@ -5305,7 +5305,7 @@
 /obj/machinery/atmospherics/pipe/manifold/green/visible{
 	dir = 4
 	},
-/obj/machinery/airalarm/engine{
+/obj/machinery/airalarm/unlocked/engine{
 	dir = 4;
 	pixel_x = -24
 	},

--- a/_maps/shuttles/pirate_default.dmm
+++ b/_maps/shuttles/pirate_default.dmm
@@ -6,7 +6,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 4;
 	pixel_x = -24
 	},
@@ -91,7 +91,7 @@
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/shuttle/pirate)
 "ak" = (
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 4;
 	pixel_x = -24
 	},
@@ -173,7 +173,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 8;
 	pixel_x = 24
 	},
@@ -321,7 +321,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 1;
 	pixel_y = -24
 	},
@@ -562,7 +562,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	pixel_y = 24
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -678,7 +678,7 @@
 /turf/open/floor/plasteel,
 /area/shuttle/pirate)
 "bC" = (
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 8;
 	pixel_x = 24
 	},
@@ -1020,7 +1020,7 @@
 "np" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/bot,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	pixel_y = 24
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -1111,7 +1111,7 @@
 /turf/open/floor/plasteel,
 /area/shuttle/pirate)
 "OD" = (
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	pixel_y = 24
 	},
 /obj/structure/sign/poster/contraband/random{
@@ -1142,7 +1142,7 @@
 /obj/effect/mob_spawn/human/pirate/captain{
 	dir = 4
 	},
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	pixel_y = 24
 	},
 /obj/effect/decal/cleanable/dirt,

--- a/_maps/shuttles/ruin_caravan_victim.dmm
+++ b/_maps/shuttles/ruin_caravan_victim.dmm
@@ -28,7 +28,7 @@
 /turf/open/floor/plasteel/airless,
 /area/shuttle/caravan/freighter1)
 "bg" = (
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -338,7 +338,7 @@
 	},
 /area/shuttle/caravan/freighter1)
 "qM" = (
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 4;
 	pixel_x = -24
 	},
@@ -365,7 +365,7 @@
 	pixel_x = 1;
 	pixel_y = 5
 	},
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	pixel_y = 24
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -409,7 +409,7 @@
 /obj/structure/bed,
 /obj/item/bedsheet,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 8;
 	pixel_x = 24
 	},
@@ -729,7 +729,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -906,7 +906,7 @@
 /obj/structure/bed,
 /obj/item/bedsheet,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 8;
 	pixel_x = 24
 	},
@@ -1024,7 +1024,7 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/caravan/freighter1)
 "UW" = (
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 8;
 	pixel_x = 24
 	},
@@ -1088,7 +1088,7 @@
 /turf/open/floor/plasteel/dark/airless,
 /area/shuttle/caravan/freighter1)
 "WU" = (
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 4;
 	pixel_x = -24
 	},

--- a/_maps/shuttles/ruin_pirate_cutter.dmm
+++ b/_maps/shuttles/ruin_pirate_cutter.dmm
@@ -92,7 +92,7 @@
 "fS" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 4;
 	pixel_x = -24
 	},
@@ -191,7 +191,7 @@
 /area/shuttle/caravan/pirate)
 "jo" = (
 /obj/structure/table,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	pixel_y = 24
 	},
 /obj/item/ammo_box/a40mm,
@@ -714,7 +714,7 @@
 	pixel_x = -25
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 8;
 	pixel_x = 24
 	},
@@ -723,7 +723,7 @@
 /area/shuttle/caravan/pirate)
 "DY" = (
 /obj/structure/closet/crate/secure/loot,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel/dark,
@@ -861,7 +861,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/delivery,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 1;
 	pixel_y = -24
 	},

--- a/_maps/shuttles/whiteship_box.dmm
+++ b/_maps/shuttles/whiteship_box.dmm
@@ -47,7 +47,7 @@
 	dir = 1
 	},
 /obj/structure/bed,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	pixel_y = 24
 	},
 /obj/item/bedsheet,
@@ -169,7 +169,7 @@
 	pixel_x = -6;
 	pixel_y = 6
 	},
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	pixel_y = 24
 	},
 /obj/item/storage/backpack/duffelbag/med/surgery{
@@ -230,7 +230,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -599,7 +599,7 @@
 /area/shuttle/abandoned/engine)
 "aV" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 1;
 	pixel_y = -24
 	},
@@ -688,7 +688,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/crate/bin,
 /obj/item/trash/pistachios,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 1;
 	pixel_y = -24
 	},
@@ -780,7 +780,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	pixel_y = 24
 	},
 /obj/machinery/light/small/built{
@@ -831,7 +831,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	pixel_y = 24
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -898,7 +898,7 @@
 /obj/structure/closet/secure_closet/medical2{
 	anchored = 1
 	},
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 8;
 	pixel_x = 24
 	},
@@ -963,7 +963,7 @@
 /obj/structure/closet/firecloset{
 	anchored = 1
 	},
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 4;
 	pixel_x = -24
 	},
@@ -1527,7 +1527,7 @@
 /obj/item/pen{
 	pixel_x = 4
 	},
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	pixel_y = 24
 	},
 /obj/item/flashlight/pen{
@@ -1597,7 +1597,7 @@
 /obj/machinery/vending/medical{
 	req_access = null
 	},
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel/white,
@@ -1991,7 +1991,7 @@
 /obj/machinery/light/small/built{
 	dir = 8
 	},
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 4;
 	pixel_x = -24
 	},

--- a/_maps/shuttles/whiteship_delta.dmm
+++ b/_maps/shuttles/whiteship_delta.dmm
@@ -87,7 +87,7 @@
 /obj/structure/bed,
 /obj/item/bedsheet/centcom,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 8;
 	pixel_x = 24
 	},
@@ -101,7 +101,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 8;
 	pixel_x = 24
 	},
@@ -417,7 +417,7 @@
 "aT" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	pixel_y = 24
 	},
 /obj/machinery/firealarm{
@@ -646,7 +646,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 4;
 	pixel_x = -24
 	},
@@ -748,7 +748,7 @@
 	pixel_x = -3;
 	pixel_y = 5
 	},
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 1;
 	pixel_y = -24
 	},
@@ -905,7 +905,7 @@
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/bar)
 "bL" = (
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 1;
 	pixel_y = -24
 	},
@@ -1016,7 +1016,7 @@
 "bU" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 8;
 	pixel_x = 24
 	},
@@ -1246,7 +1246,7 @@
 /obj/item/megaphone,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 4;
 	pixel_x = -24
 	},
@@ -1518,7 +1518,7 @@
 /obj/item/extinguisher,
 /obj/item/extinguisher,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/box/white/corners{
@@ -1564,7 +1564,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 4;
 	pixel_x = -24
 	},
@@ -1660,7 +1660,7 @@
 	pixel_y = 3
 	},
 /obj/item/radio/off,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -2052,7 +2052,7 @@
 /obj/machinery/light/small/built{
 	dir = 4
 	},
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 8;
 	pixel_x = 24
 	},
@@ -2174,7 +2174,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 1;
 	pixel_y = -24
 	},

--- a/_maps/shuttles/whiteship_kilo.dmm
+++ b/_maps/shuttles/whiteship_kilo.dmm
@@ -95,7 +95,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 1;
 	pixel_y = -24
 	},
@@ -354,7 +354,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/cobweb,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 4;
 	pixel_x = -24
 	},
@@ -479,7 +479,7 @@
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
 	},
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 8;
 	pixel_x = 24
 	},
@@ -732,7 +732,7 @@
 /obj/structure/sign/warning/vacuum/external{
 	pixel_x = -32
 	},
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 1;
 	pixel_y = -24
 	},
@@ -777,7 +777,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/turf_decal/delivery,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 1;
 	pixel_y = -24
 	},
@@ -1108,7 +1108,7 @@
 "bX" = (
 /obj/structure/bed,
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 4;
 	pixel_x = -24
 	},
@@ -1126,7 +1126,7 @@
 "bZ" = (
 /obj/structure/bed,
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 8;
 	pixel_x = 24
 	},
@@ -1148,7 +1148,7 @@
 	pixel_x = -8;
 	pixel_y = 8
 	},
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	pixel_y = 22
 	},
 /turf/open/floor/carpet,
@@ -1194,7 +1194,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 4;
 	pixel_x = -24
 	},
@@ -1710,7 +1710,7 @@
 	icon_state = "trimline_fill";
 	dir = 1
 	},
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 1;
 	pixel_y = -24
 	},
@@ -1811,7 +1811,7 @@
 	pixel_x = 12;
 	pixel_y = 6
 	},
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 1;
 	pixel_y = -24
 	},

--- a/_maps/shuttles/whiteship_meta.dmm
+++ b/_maps/shuttles/whiteship_meta.dmm
@@ -174,7 +174,7 @@
 /area/shuttle/abandoned/crew)
 "au" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	pixel_y = 24
 	},
 /obj/structure/closet/secure_closet/personal,
@@ -560,7 +560,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/stripes/white/line{
@@ -654,7 +654,7 @@
 /area/shuttle/abandoned/crew)
 "bc" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	pixel_y = 24
 	},
 /obj/effect/decal/cleanable/dirt/dust,
@@ -725,7 +725,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 1;
 	pixel_y = -24
 	},
@@ -960,7 +960,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 8;
 	pixel_x = 24
 	},
@@ -1297,7 +1297,7 @@
 /area/shuttle/abandoned/bar)
 "cc" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 8;
 	pixel_x = 24
 	},
@@ -1336,7 +1336,7 @@
 /area/shuttle/abandoned/bridge)
 "ce" = (
 /obj/structure/table,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	pixel_y = 24
 	},
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1606,7 +1606,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 4;
 	pixel_x = -24
 	},
@@ -1896,7 +1896,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 4;
 	pixel_x = -24
 	},
@@ -1961,7 +1961,7 @@
 /area/shuttle/abandoned/bar)
 "cU" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 4;
 	pixel_x = -24
 	},
@@ -2009,7 +2009,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	pixel_y = 24
 	},
 /obj/machinery/light/small/built{
@@ -2191,7 +2191,7 @@
 "dn" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/hydroponics/constructable,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 8;
 	pixel_x = 24
 	},
@@ -2310,7 +2310,7 @@
 "dy" = (
 /obj/machinery/light/small/built,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/airalarm/all_access{
+/obj/machinery/airalarm/unlocked/all_access{
 	dir = 1;
 	pixel_y = -24
 	},

--- a/code/__DEFINES/directional.dm
+++ b/code/__DEFINES/directional.dm
@@ -1,0 +1,35 @@
+/// Create directional subtypes for a path to simplify mapping.
+#define MAPPING_DIRECTIONAL_HELPERS(path, offset) ##path/directional/north {\
+	dir = NORTH; \
+	pixel_y = offset; \
+} \
+##path/directional/south {\
+	dir = SOUTH; \
+	pixel_y = -offset; \
+} \
+##path/directional/east {\
+	dir = EAST; \
+	pixel_x = offset; \
+} \
+##path/directional/west {\
+	dir = WEST; \
+	pixel_x = -offset; \
+}
+
+/// Ditto, but with inverted icon directions.
+#define INVERTED_MAPPING_DIRECTIONAL_HELPERS(path, offset) ##path/directional/north {\
+	dir = SOUTH; \
+	pixel_y = offset; \
+} \
+##path/directional/south {\
+	dir = NORTH; \
+	pixel_y = -offset; \
+} \
+##path/directional/east {\
+	dir = WEST; \
+	pixel_x = offset; \
+} \
+##path/directional/west {\
+	dir = EAST; \
+	pixel_x = -offset; \
+}

--- a/code/game/machinery/bounty_board.dm
+++ b/code/game/machinery/bounty_board.dm
@@ -19,6 +19,8 @@ GLOBAL_LIST_EMPTY(request_list)
 	///Text of the currently written bounty
 	var/bounty_text = ""
 
+INVERTED_MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/bounty_board, 30)
+
 /obj/machinery/bounty_board/Initialize(mapload, ndir, building)
 	. = ..()
 	GLOB.allbountyboards += src

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -38,6 +38,8 @@
 	var/last_alarm = 0
 	var/area/myarea = null
 
+INVERTED_MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/firealarm, 28)
+
 /obj/machinery/firealarm/Initialize(mapload, dir, building)
 	. = ..()
 	if(dir)
@@ -325,6 +327,8 @@
 	name = "\improper PARTY BUTTON"
 	desc = "Cuban Pete is in the house!"
 	var/static/party_overlay
+
+INVERTED_MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/firealarm/partyalarm, 28)
 
 /obj/machinery/firealarm/partyalarm/reset()
 	if (machine_stat & (NOPOWER|BROKEN))

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -203,9 +203,13 @@ GLOBAL_LIST_EMPTY(allCasters)
 	var/datum/newscaster/feed_channel/viewing_channel = null
 	var/allow_comments = 1
 
+MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
+
 /obj/machinery/newscaster/security_unit
 	name = "security newscaster"
 	securityCaster = 1
+
+MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster/security_unit, 30)
 
 /obj/machinery/newscaster/Initialize(mapload, ndir, building)
 	. = ..()

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -34,6 +34,8 @@
 	var/index1			// display index for scrolling messages or 0 if non-scrolling
 	var/index2
 
+MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/status_display, 32)
+
 /// Immediately blank the display.
 /obj/machinery/status_display/proc/remove_display()
 	cut_overlays()
@@ -160,6 +162,8 @@
 	var/friendc = FALSE      // track if Friend Computer mode
 	var/last_picture  // For when Friend Computer mode is undone
 
+MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/status_display/evac, 32)
+
 /obj/machinery/status_display/evac/Initialize()
 	. = ..()
 	// register for radio system
@@ -225,6 +229,8 @@
 /obj/machinery/status_display/supply
 	name = "supply display"
 
+MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/status_display/supply, 32)
+
 /obj/machinery/status_display/supply/process()
 	if(machine_stat & NOPOWER)
 		// No power, no processing.
@@ -269,6 +275,8 @@
 	name = "shuttle display"
 	var/shuttle_id
 
+MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/status_display/shuttle, 32)
+
 /obj/machinery/status_display/shuttle/process()
 	if(!shuttle_id || (machine_stat & NOPOWER))
 		// No power, no processing.
@@ -305,6 +313,8 @@
 
 	var/mode = SD_BLANK
 	var/emotion = "Neutral"
+
+MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/status_display/ai, 32)
 
 /obj/machinery/status_display/ai/Initialize()
 	. = ..()

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -8,6 +8,8 @@
 	dog_fashion = null
 	unscrewed = FALSE
 
+MAPPING_DIRECTIONAL_HELPERS(/obj/item/radio/intercom, 26)
+
 /obj/item/radio/intercom/unscrewed
 	unscrewed = TRUE
 

--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -10,6 +10,8 @@
 	var/obj/item/extinguisher/stored_extinguisher
 	var/opened = FALSE
 
+MAPPING_DIRECTIONAL_HELPERS(/obj/structure/extinguisher_cabinet, 28)
+
 /obj/structure/extinguisher_cabinet/Initialize(mapload, ndir, building)
 	. = ..()
 	if(building)

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -104,7 +104,11 @@
 		/datum/gas/hydrogen			= new/datum/tlv/dangerous
 	)
 
-/obj/machinery/airalarm/server // No checks here.
+/// Pixel offsets are overwritten by new() ATM
+INVERTED_MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/airalarm, 28)
+
+/// Air alarm variant that doesn't perform any checks, for use in server rooms or other extreme environments.
+/obj/machinery/airalarm/no_alarm
 	TLV = list(
 		"pressure"					= new/datum/tlv/no_checks,
 		"temperature"				= new/datum/tlv/no_checks,
@@ -125,7 +129,10 @@
 		/datum/gas/hydrogen			= new/datum/tlv/no_checks
 	)
 
-/obj/machinery/airalarm/kitchen_cold_room // Kitchen cold rooms start off at -80°C or 193.15°K.
+INVERTED_MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/airalarm/no_alarm, 28)
+
+/// Air alarm variant for freezers - Kitchen cold rooms start off at -80°C or 193.15°K.
+/obj/machinery/airalarm/kitchen_cold_room
 	TLV = list(
 		"pressure"					= new/datum/tlv(ONE_ATMOSPHERE * 0.8, ONE_ATMOSPHERE*  0.9, ONE_ATMOSPHERE * 1.1, ONE_ATMOSPHERE * 1.2), // kPa
 		"temperature"				= new/datum/tlv(T0C-273.15, T0C-100, T0C-60, T0C),
@@ -146,49 +153,48 @@
 		/datum/gas/hydrogen			= new/datum/tlv/dangerous
 	)
 
+INVERTED_MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/airalarm/kitchen_cold_room, 28)
+
 /obj/machinery/airalarm/unlocked
 	locked = FALSE
 
-/obj/machinery/airalarm/engine
+INVERTED_MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/airalarm/unlocked, 28)
+
+/// Also allows engineers to access it.
+/obj/machinery/airalarm/unlocked/engine
 	name = "engine air alarm"
-	locked = FALSE
 	req_access = null
 	req_one_access = list(ACCESS_ATMOSPHERICS, ACCESS_ENGINE)
 
-/obj/machinery/airalarm/mixingchamber
+INVERTED_MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/airalarm/unlocked/engine, 28)
+
+/// Also allows toxins scientists to access it.
+/obj/machinery/airalarm/unlocked/mixingchamber
 	name = "chamber air alarm"
-	locked = FALSE
 	req_access = null
 	req_one_access = list(ACCESS_ATMOSPHERICS, ACCESS_TOXINS)
 
-/obj/machinery/airalarm/all_access
+INVERTED_MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/airalarm/unlocked/mixingchamber, 28)
+
+/obj/machinery/airalarm/unlocked/all_access
 	name = "all-access air alarm"
 	desc = "This particular atmos control unit appears to have no access restrictions."
-	locked = FALSE
 	req_access = null
 	req_one_access = null
 
-/obj/machinery/airalarm/syndicate //general syndicate access
+INVERTED_MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/airalarm/unlocked/all_access, 28)
+
+/// Allows anyone with Syndicate Access (150) to unlock/lock it.
+/obj/machinery/airalarm/syndicate
 	req_access = list(ACCESS_SYNDICATE)
 
-/obj/machinery/airalarm/away //general away mission access
+INVERTED_MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/airalarm/syndicate, 28)
+
+/// General Away Mission / Ruin Access
+/obj/machinery/airalarm/ruin_access
 	req_access = list(ACCESS_AWAY_GENERAL)
 
-/obj/machinery/airalarm/directional/north //Pixel offsets get overwritten on New()
-	dir = SOUTH
-	pixel_y = 28
-
-/obj/machinery/airalarm/directional/south
-	dir = NORTH
-	pixel_y = -28
-
-/obj/machinery/airalarm/directional/east
-	dir = WEST
-	pixel_x = 28
-
-/obj/machinery/airalarm/directional/west
-	dir = EAST
-	pixel_x = -28
+INVERTED_MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/airalarm/ruin_access, 28)
 
 //all air alarms in area are connected via magic
 /area

--- a/tetrastation.dme
+++ b/tetrastation.dme
@@ -42,6 +42,7 @@
 #include "code\__DEFINES\contracts.dm"
 #include "code\__DEFINES\cooldowns.dm"
 #include "code\__DEFINES\cult.dm"
+#include "code\__DEFINES\directional.dm"
 #include "code\__DEFINES\diseases.dm"
 #include "code\__DEFINES\DNA.dm"
 #include "code\__DEFINES\dye_keys.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a mapping directional helper and converts a bunch of stuff to use it, transferring this new support to Holestation and Spider's nest. Also repaths a handful of air alarm paths because ///reasons///
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog
:cl:
code: A bunch of wall items have been converted to directional subtypes, finally dealing with the MESS that was intercomm subtypes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
