### PR TITLE
More Holestation Patches + Missed Plasteel Tile Path

### DIFF
--- a/_maps/map_files/HoleStation/holestation.dmm
+++ b/_maps/map_files/HoleStation/holestation.dmm
@@ -1845,9 +1845,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/door/airlock/engineering{
-	req_access_txt = "61"
-	},
+/obj/machinery/door/airlock/engineering,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -19462,9 +19460,7 @@
 /turf/open/floor/iron,
 /area/station/crew_quarters/dorms)
 "vYK" = (
-/obj/machinery/door/airlock/engineering{
-	req_access_txt = "61"
-	},
+/obj/machinery/door/airlock/engineering,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
 /obj/effect/mapping_helpers/airlock/autoname,

--- a/_maps/map_files/HoleStation/holestation.dmm
+++ b/_maps/map_files/HoleStation/holestation.dmm
@@ -2472,7 +2472,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
-/turf/open/floor/iron,
+/turf/open/floor/iron/textured,
 /area/station/hallway/secondary/exit)
 "alN" = (
 /obj/effect/turf_decal/stripes/line{
@@ -14219,6 +14219,9 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "iKH" = (
@@ -15856,6 +15859,9 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -17506,6 +17512,7 @@
 /area/station/crew_quarters/heads/hop)
 "roD" = (
 /obj/effect/turf_decal/siding/white,
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/half,
 /area/station/hallway/secondary/entry)
 "rpy" = (
@@ -18812,7 +18819,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/autoname,
-/turf/open/floor/iron,
+/turf/open/floor/iron/textured,
 /area/station/hallway/secondary/exit)
 "unA" = (
 /obj/effect/landmark/start/assistant,
@@ -20361,6 +20368,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /turf/open/floor/iron,

--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -264,7 +264,7 @@
 	new /obj/item/clothing/shoes/combat/sneakboots(src)
 
 //floorbot assembly
-/obj/item/storage/toolbox/attackby(obj/item/stack/tile/plasteel/T, mob/user, params)
+/obj/item/storage/toolbox/attackby(/obj/item/stack/tile/iron/T, /mob/user, params)
 	var/list/allowed_toolbox = list(/obj/item/storage/toolbox/emergency,	//which toolboxes can be made into floorbots
 							/obj/item/storage/toolbox/electrical,
 							/obj/item/storage/toolbox/mechanical,


### PR DESCRIPTION
FRICK

## Changelog
:cl:
fix: Some Holestation airlocks no longer require the same object twice.
fix: Compiling works again! OOPS
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
