### PR TITLE
[PORT] Fixes Multi-Z Vis Overlays - Fixes a Goofy Spot on Holestation

### DIFF
--- a/_maps/map_files/HoleStation/holestation.dmm
+++ b/_maps/map_files/HoleStation/holestation.dmm
@@ -8832,14 +8832,6 @@
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/wood,
 /area/station/crew_quarters/dorms)
-"aOX" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/cable/layer3,
-/turf/open/openspace,
-/area/station/engineering/atmos)
 "aPa" = (
 /obj/machinery/atmospherics/components/unary/passive_vent,
 /turf/open/floor/engine/hull,
@@ -119924,7 +119916,7 @@ aHA
 apR
 akF
 aPW
-aOX
+aQX
 aQX
 aQX
 aQX

--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -49,7 +49,7 @@
 /obj/effect/overlay/vis
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	anchored = TRUE
-	vis_flags = NONE
+	vis_flags = VIS_INHERIT_PLANE
 	///When detected to be unused it gets set to world.time, after a while it gets removed
 	var/unused = 0
 	///overlays which go unused for this amount of time get cleaned up


### PR DESCRIPTION
:cl: itsmeow for Beestation
fix: Fixed fire alarm and APC overlays poking through Z levels.
/:cl:

This also fixes light overlays doing the same, but editing other's CLs for their work verbatim is a nono in my book.