### PR TITLE
Comms Agents Now Have Spaceflight Priveleges

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -205,6 +205,7 @@
 /obj/item/clothing/mask/gas/syndicate,
 /obj/item/tank/internals/oxygen,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/red,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/listeningstation)
 "kG" = (

--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -5,12 +5,12 @@
 "ab" = (
 /turf/closed/mineral/random,
 /area/ruin/unpowered/no_grav)
-"ae" = (
-/obj/structure/closet/crate/engineering/electrical,
-/obj/item/storage/toolbox/electrical,
-/obj/item/stock_parts/cell/hyper,
-/obj/item/stock_parts/cell/high,
-/obj/effect/turf_decal/delivery,
+"al" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "commsagent_hangar_warehouse"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/listeningstation)
 "aA" = (
@@ -19,18 +19,22 @@
 	name = "interior hull plating"
 	},
 /area/ruin/space/has_grav/listeningstation)
-"aP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/listeningstation)
 "bk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 5
 	},
 /turf/closed/mineral/random,
 /area/ruin/unpowered/no_grav)
-"bz" = (
+"bl" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"bx" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
 	id = "commsagent_hangar_door";
@@ -55,23 +59,40 @@
 	name = "interior hull plating"
 	},
 /area/ruin/space/has_grav/listeningstation)
-"cw" = (
+"bU" = (
+/obj/machinery/suit_storage_unit/open,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/broken{
-	dir = 8
-	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/listeningstation)
+"ca" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/computer/mech_bay_power_console,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/listeningstation)
-"cI" = (
-/obj/machinery/firealarm/directional/north,
+"cm" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/dim{
+	dir = 4
+	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/listeningstation)
-"cU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/effect/turf_decal/stripes/line{
+"cE" = (
+/obj/structure/railing{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"db" = (
+/obj/machinery/light/dim{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/listeningstation)
@@ -81,90 +102,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/listeningstation)
-"dU" = (
-/obj/structure/cable,
+"fg" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm/directional/south,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/listeningstation)
-"eQ" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/closet/crate{
-	name = "food crate"
-	},
-/obj/item/reagent_containers/food/drinks/waterbottle/large{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/food/drinks/waterbottle/large{
-	pixel_x = 2;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/food/drinks/waterbottle/large{
-	pixel_x = -2
-	},
-/obj/item/reagent_containers/food/drinks/waterbottle/large{
-	pixel_x = 5
-	},
-/obj/item/reagent_containers/food/drinks/waterbottle/large{
-	pixel_x = 1;
-	pixel_y = -3
-	},
-/obj/item/reagent_containers/food/drinks/waterbottle/large{
-	pixel_x = 8;
-	pixel_y = -3
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/listeningstation)
-"gi" = (
-/obj/effect/turf_decal/delivery,
-/obj/item/reagent_containers/food/snacks/canned/beans{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/food/snacks/canned/beans{
-	pixel_x = 2;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/food/snacks/canned/beans{
-	pixel_x = -2
-	},
-/obj/item/reagent_containers/food/snacks/canned/beans{
-	pixel_x = 5
-	},
-/obj/item/reagent_containers/food/snacks/canned/beans{
-	pixel_x = 1;
-	pixel_y = -3
-	},
-/obj/item/reagent_containers/food/snacks/canned/beans{
-	pixel_x = 8;
-	pixel_y = -3
-	},
-/obj/structure/closet/crate{
-	name = "food crate"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 4
 	},
-/obj/item/pizzabox/margherita,
 /turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/listeningstation)
-"gF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/listeningstation)
-"gM" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
 /area/ruin/space/has_grav/listeningstation)
 "hc" = (
 /obj/structure/railing,
@@ -178,19 +121,36 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/listeningstation)
-"hx" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
-/turf/open/floor/mineral/plastitanium/red,
+"hp" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/listeningstation)
 "hy" = (
 /obj/structure/railing,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/listeningstation)
-"ig" = (
-/obj/machinery/light/dim{
-	dir = 4
+"hC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"hY" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door{
+	id = "commsagent_hangar_warehouse";
+	name = "Hangar Warehouse";
+	req_access = list(150);
+	pixel_y = -24
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron,
 /area/ruin/space/has_grav/listeningstation)
 "iv" = (
 /obj/machinery/atmospherics/components/binary/valve/on/layer3,
@@ -200,21 +160,38 @@
 	},
 /area/ruin/space/has_grav/listeningstation)
 "iy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/listeningstation)
-"jf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/mech_bay_recharge_port{
-	dir = 1
-	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/listeningstation)
 "jg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"ji" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/listeningstation)
+"jI" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"kT" = (
+/obj/structure/railing,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/listeningstation)
 "kV" = (
@@ -230,35 +207,15 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/listeningstation)
-"mh" = (
-/obj/effect/turf_decal/delivery,
-/obj/item/reagent_containers/food/snacks/canned/beans{
-	pixel_x = -5;
-	pixel_y = 3
+"lY" = (
+/obj/structure/railing,
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/item/reagent_containers/food/snacks/canned/beans{
-	pixel_x = 2;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/food/snacks/canned/beans{
-	pixel_x = -2
-	},
-/obj/item/reagent_containers/food/snacks/canned/beans{
-	pixel_x = 5
-	},
-/obj/item/reagent_containers/food/snacks/canned/beans{
-	pixel_x = 1;
-	pixel_y = -3
-	},
-/obj/item/reagent_containers/food/snacks/canned/beans{
-	pixel_x = 8;
-	pixel_y = -3
-	},
-/obj/structure/closet/crate{
-	name = "food crate"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/pizzabox/margherita,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"mi" = (
+/obj/machinery/airalarm/syndicate/directional/south,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/listeningstation)
 "mC" = (
@@ -276,6 +233,41 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/listeningstation)
+"mV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
+"ni" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/closet/crate{
+	name = "food crate"
+	},
+/obj/item/reagent_containers/food/drinks/waterbottle/large{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/drinks/waterbottle/large{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/drinks/waterbottle/large{
+	pixel_x = -2
+	},
+/obj/item/reagent_containers/food/drinks/waterbottle/large{
+	pixel_x = 5
+	},
+/obj/item/reagent_containers/food/drinks/waterbottle/large{
+	pixel_x = 1;
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/food/drinks/waterbottle/large{
+	pixel_x = 8;
+	pixel_y = -3
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
 "nl" = (
 /obj/structure/railing,
 /obj/structure/cable,
@@ -286,45 +278,15 @@
 /area/ruin/space/has_grav/listeningstation)
 "nn" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/listeningstation)
-"oq" = (
-/obj/machinery/suit_storage_unit/open,
+"oa" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/listeningstation)
-"ou" = (
-/obj/item/flashlight/flare,
-/obj/item/flashlight/flare,
-/obj/item/flashlight/flare,
-/obj/item/flashlight/flare,
-/obj/item/flashlight/flare,
-/obj/item/flashlight,
-/obj/item/flashlight,
-/obj/item/shovel,
-/obj/item/pickaxe/drill,
-/obj/item/pickaxe/drill,
-/obj/effect/turf_decal/delivery,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 4
+/obj/machinery/light/broken{
+	dir = 8
 	},
-/obj/structure/closet/crate,
 /turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/listeningstation)
-"ow" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/listeningstation)
-"oO" = (
-/obj/machinery/door/airlock/hatch,
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/listeningstation)
 "oP" = (
 /obj/machinery/power/terminal{
@@ -342,6 +304,12 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/listeningstation)
 "qf" = (
@@ -354,106 +322,126 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/listeningstation)
-"qi" = (
-/obj/machinery/airalarm/syndicate/directional/south,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/listeningstation)
-"qt" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/listeningstation)
 "qG" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer1{
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/listeningstation)
+"qW" = (
+/obj/structure/closet/crate/engineering/electrical,
+/obj/item/storage/toolbox/electrical,
+/obj/item/stock_parts/cell/hyper,
+/obj/item/stock_parts/cell/high,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
+"qY" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/listeningstation)
+"rb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
+"rg" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/listeningstation)
 "rj" = (
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
 /area/ruin/space/has_grav/listeningstation)
-"uL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 8
+"rW" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "commsagent_hangar_warehouse"
 	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/listeningstation)
-"uT" = (
+"sE" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"sW" = (
+/obj/effect/turf_decal/delivery,
+/obj/item/reagent_containers/food/snacks/canned/beans{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/snacks/canned/beans{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/snacks/canned/beans{
+	pixel_x = -2
+	},
+/obj/item/reagent_containers/food/snacks/canned/beans{
+	pixel_x = 5
+	},
+/obj/item/reagent_containers/food/snacks/canned/beans{
+	pixel_x = 1;
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/food/snacks/canned/beans{
+	pixel_x = 8;
+	pixel_y = -3
+	},
+/obj/structure/closet/crate{
+	name = "food crate"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/item/pizzabox/margherita,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
+"tj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/listeningstation)
-"va" = (
+"vq" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
+/turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/listeningstation)
-"wf" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+"vH" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/listeningstation)
-"wl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 5
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/listeningstation)
-"wv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/turf/open/floor/iron,
 /area/ruin/space/has_grav/listeningstation)
 "wB" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "commsagent_hangar_warehouse"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/listeningstation)
-"wO" = (
-/turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space/has_grav/listeningstation)
-"xu" = (
+"wD" = (
+/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/door{
-	id = "commsagent_hangar_warehouse";
-	name = "Hangar Warehouse";
-	req_access = list(150);
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/ruin/space/has_grav/listeningstation)
-"ym" = (
+"xi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"zC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/listeningstation)
-"yV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 4
-	},
-/turf/open/floor/iron,
 /area/ruin/space/has_grav/listeningstation)
 "zK" = (
 /obj/structure/railing/corner{
@@ -471,11 +459,6 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/listeningstation)
-"Ak" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/listeningstation)
 "An" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -487,31 +470,14 @@
 /obj/machinery/power/rtg/advanced,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/syndicate/directional/north,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/listeningstation)
-"BH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/listeningstation)
-"BU" = (
-/obj/machinery/power/rtg/advanced,
-/obj/structure/cable,
+"Cn" = (
+/obj/structure/rack,
+/obj/item/clothing/mask/gas/syndicate,
+/obj/item/tank/internals/oxygen,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/listeningstation)
-"Cj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/obj/effect/spawner/lootdrop/whiteship_cere_ripley,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/listeningstation)
-"CL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/listeningstation)
 "CU" = (
 /obj/structure/railing,
@@ -532,36 +498,35 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/listeningstation)
-"Es" = (
-/obj/structure/railing{
+"En" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
+"Fk" = (
+/obj/structure/railing,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
-	dir = 1
+	dir = 9
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/listeningstation)
-"Fr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/computer/mech_bay_power_console,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/listeningstation)
-"FJ" = (
+"Fm" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/listeningstation)
-"FP" = (
-/obj/structure/rack,
-/obj/item/clothing/mask/gas/syndicate,
-/obj/item/tank/internals/oxygen,
+"FD" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/listeningstation)
 "FQ" = (
@@ -571,21 +536,6 @@
 	name = "interior hull plating"
 	},
 /area/ruin/space/has_grav/listeningstation)
-"FZ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine/hull{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15";
-	name = "interior hull plating"
-	},
-/area/ruin/space/has_grav/listeningstation)
-"Hf" = (
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/listeningstation)
-"Hk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/syndicate/directional/north,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/listeningstation)
 "Hn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/layer_manifold{
@@ -594,27 +544,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/listeningstation)
-"Hv" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/listeningstation)
 "Ib" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/listeningstation)
-"IF" = (
-/obj/structure/railing{
-	dir = 1
-	},
+"Ie" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 4
-	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
+"IO" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/listeningstation)
 "IP" = (
@@ -632,35 +576,98 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/listeningstation)
-"JN" = (
-/obj/structure/closet/crate/radiation,
-/obj/item/clothing/head/radiation,
-/obj/item/clothing/suit/radiation,
-/obj/item/geiger_counter,
+"IY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
+"Jm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/syndicate/directional/north,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"Kl" = (
 /obj/effect/turf_decal/delivery,
+/obj/item/reagent_containers/food/snacks/canned/beans{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/snacks/canned/beans{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/snacks/canned/beans{
+	pixel_x = -2
+	},
+/obj/item/reagent_containers/food/snacks/canned/beans{
+	pixel_x = 5
+	},
+/obj/item/reagent_containers/food/snacks/canned/beans{
+	pixel_x = 1;
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/food/snacks/canned/beans{
+	pixel_x = 8;
+	pixel_y = -3
+	},
+/obj/structure/closet/crate{
+	name = "food crate"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/pizzabox/margherita,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
+"KG" = (
+/obj/item/flashlight/flare,
+/obj/item/flashlight/flare,
+/obj/item/flashlight/flare,
+/obj/item/flashlight/flare,
+/obj/item/flashlight/flare,
+/obj/item/flashlight,
+/obj/item/flashlight,
+/obj/item/shovel,
+/obj/item/pickaxe/drill,
+/obj/item/pickaxe/drill,
+/obj/effect/turf_decal/delivery,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/closet/crate,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/listeningstation)
 "KI" = (
 /turf/closed/wall/r_wall,
 /area/ruin/space/has_grav/listeningstation)
-"LF" = (
+"KP" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 9
-	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/spawner/lootdrop/whiteship_cere_ripley,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/listeningstation)
-"LG" = (
+"Lx" = (
+/obj/machinery/door/airlock/hatch,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/listeningstation)
+"LK" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"Mc" = (
 /obj/structure/railing{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/listeningstation)
 "Mi" = (
@@ -690,13 +697,6 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/listeningstation)
-"Mt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/listeningstation)
 "MS" = (
 /obj/structure/railing{
 	dir = 1
@@ -710,7 +710,45 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/listeningstation)
-"Na" = (
+"Nb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/listeningstation)
+"Ne" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/mech_bay_recharge_port{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
+"Nx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door{
+	id = "commsagent_hangar_warehouse";
+	name = "Hangar Warehouse";
+	req_access = list(150);
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
+"Os" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"OD" = (
 /obj/structure/railing{
 	dir = 4
 	},
@@ -721,92 +759,96 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/listeningstation)
-"Nb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/listeningstation)
-"Nr" = (
-/obj/structure/railing,
+"OR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 9
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/listeningstation)
-"Nw" = (
+"Pz" = (
+/obj/machinery/firealarm/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/listeningstation)
-"NT" = (
-/obj/structure/table/reinforced,
+"PC" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/listeningstation)
-"Pv" = (
-/obj/structure/cable,
+"Qz" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/listeningstation)
-"PE" = (
-/obj/structure/railing,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/listeningstation)
-"Qm" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "commsagent_hangar_warehouse"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/listeningstation)
 "QE" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/listeningstation)
-"Rb" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+"RA" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/listeningstation)
+"SF" = (
+/obj/structure/closet/crate/radiation,
+/obj/item/clothing/head/radiation,
+/obj/item/clothing/suit/radiation,
+/obj/item/geiger_counter,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
+"SW" = (
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/listeningstation)
+"To" = (
+/obj/structure/railing{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"TR" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/listeningstation)
-"Sd" = (
-/obj/structure/cable,
+"Uz" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/door{
-	id = "commsagent_hangar_warehouse";
-	name = "Hangar Warehouse";
-	req_access = list(150);
-	pixel_y = -24
+/turf/open/floor/engine/hull{
+	initial_gas_mix = "o2=22;n2=82;TEMP=293.15";
+	name = "interior hull plating"
 	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/iron,
 /area/ruin/space/has_grav/listeningstation)
-"SP" = (
-/obj/structure/cable,
+"UB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/listeningstation)
 "Vg" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"VY" = (
 /obj/structure/railing{
 	dir = 1
 	},
@@ -819,29 +861,11 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/listeningstation)
-"Xk" = (
+"XF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space/has_grav/listeningstation)
-"XA" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/listeningstation)
-"XL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 5
-	},
-/turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/listeningstation)
 "XM" = (
 /obj/structure/railing{
@@ -853,11 +877,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/listeningstation)
-"YO" = (
+"XU" = (
+/obj/machinery/power/rtg/advanced,
+/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/broken{
-	dir = 8
-	},
+/obj/machinery/airalarm/syndicate/directional/north,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/listeningstation)
 "YR" = (
@@ -882,13 +906,6 @@
 "Zu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/closed/wall/r_wall,
-/area/ruin/space/has_grav/listeningstation)
-"ZJ" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "commsagent_hangar_warehouse"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/listeningstation)
 
 (1,1,1) = {"
@@ -1141,21 +1158,21 @@ ab
 ab
 ab
 KI
-Hv
+LK
 pq
 pq
 pq
 pq
 pq
 pq
-Hv
-Hv
-Hv
-Hv
-yV
-Hv
-yV
-Hv
+LK
+LK
+LK
+LK
+sE
+LK
+sE
+LK
 pq
 pq
 KI
@@ -1181,21 +1198,21 @@ KI
 KI
 KI
 KI
-gM
+wD
 Mp
 mC
-XA
+To
 mC
-XA
-mC
-mC
+To
 mC
 mC
 mC
-Na
 mC
-Na
-wf
+mC
+OD
+mC
+OD
+Os
 kV
 QE
 KI
@@ -1217,9 +1234,9 @@ aa
 ab
 ab
 KI
-BU
-YO
-BH
+Aq
+FD
+nn
 KI
 Ib
 CU
@@ -1235,8 +1252,8 @@ aA
 aA
 aA
 aA
-FZ
-Vg
+Uz
+VY
 QE
 KI
 ab
@@ -1257,8 +1274,8 @@ aa
 aa
 ab
 KI
-Aq
-nn
+XU
+TR
 DN
 Mn
 An
@@ -1276,7 +1293,7 @@ aA
 aA
 aA
 aA
-Vg
+VY
 QE
 KI
 KI
@@ -1297,11 +1314,11 @@ aa
 aa
 ab
 KI
-BU
+Aq
 oP
 Nb
 rj
-Hv
+LK
 hc
 aA
 aA
@@ -1316,14 +1333,14 @@ aA
 aA
 aA
 aA
-Vg
-gM
+VY
+wD
 KI
-va
-va
-cw
-Hf
-Hf
+Ie
+Ie
+oa
+iy
+iy
 KI
 ab
 ab
@@ -1341,7 +1358,7 @@ KI
 mN
 Hn
 rj
-Hv
+LK
 hc
 aA
 aA
@@ -1357,13 +1374,13 @@ aA
 aA
 aA
 Zq
-Sd
+hY
 KI
-xu
-eQ
-eQ
-eQ
-Hf
+Nx
+ni
+ni
+ni
+iy
 KI
 ab
 ab
@@ -1381,7 +1398,7 @@ KI
 KI
 YR
 KI
-Hv
+LK
 hc
 aA
 aA
@@ -1396,14 +1413,14 @@ aA
 aA
 aA
 aA
-Vg
-FJ
-ZJ
-gF
-va
-Mt
-va
-va
+VY
+Fm
+wB
+En
+Ie
+fg
+Ie
+Ie
 KI
 ab
 ab
@@ -1421,7 +1438,7 @@ ab
 KI
 KI
 KI
-Hv
+LK
 hc
 aA
 aA
@@ -1436,14 +1453,14 @@ aA
 aA
 aA
 aA
-Vg
-FJ
-ZJ
-gF
-mh
-gi
-mh
-va
+VY
+Fm
+wB
+En
+Kl
+sW
+Kl
+Ie
 KI
 ab
 ab
@@ -1476,14 +1493,14 @@ aA
 aA
 aA
 aA
-Es
-SP
-wB
-uT
-aP
-LF
-va
-iy
+Vg
+jI
+al
+UB
+rb
+OR
+Ie
+mV
 KI
 ab
 ab
@@ -1501,7 +1518,7 @@ ab
 ab
 ab
 KI
-Hv
+LK
 hc
 aA
 aA
@@ -1516,14 +1533,14 @@ aA
 aA
 aA
 aA
-IF
-Pv
-Qm
-cU
-ym
-XL
-va
-qi
+qb
+IO
+rW
+tj
+zC
+vH
+Ie
+mi
 KI
 ab
 ab
@@ -1541,7 +1558,7 @@ ab
 ab
 ab
 KI
-Hv
+LK
 IP
 bD
 aA
@@ -1557,13 +1574,13 @@ aA
 aA
 aA
 zK
-FJ
-ZJ
-gF
-ae
-ou
-JN
-va
+Fm
+wB
+En
+qW
+KG
+SF
+Ie
 KI
 ab
 ab
@@ -1596,14 +1613,14 @@ aA
 aA
 aA
 aA
-Vg
-FJ
-ZJ
-gF
-va
-uL
-va
-va
+VY
+Fm
+wB
+En
+Ie
+Qz
+Ie
+Ie
 KI
 ab
 ab
@@ -1621,7 +1638,7 @@ ab
 ab
 ab
 KI
-Hv
+LK
 hc
 aA
 aA
@@ -1636,14 +1653,14 @@ aA
 aA
 aA
 aA
-Vg
-dU
+VY
+bl
 KI
-wl
-Cj
-jf
-Fr
-va
+IY
+KP
+Ne
+ca
+Ie
 KI
 ab
 ab
@@ -1676,14 +1693,14 @@ aA
 aA
 aA
 aA
-LG
+cE
 dj
 KI
-va
-va
-ig
-va
-va
+Ie
+Ie
+db
+Ie
+Ie
 KI
 ab
 ab
@@ -1701,8 +1718,8 @@ ab
 ab
 ab
 KI
-Hv
-PE
+LK
+kT
 aA
 aA
 aA
@@ -1716,8 +1733,8 @@ aA
 aA
 aA
 aA
-LG
-Hv
+cE
+LK
 KI
 KI
 KI
@@ -1741,8 +1758,8 @@ ab
 ab
 ab
 KI
-Hv
-PE
+LK
+kT
 aA
 aA
 aA
@@ -1756,8 +1773,8 @@ aA
 aA
 aA
 aA
-LG
-Hv
+cE
+LK
 KI
 ab
 ab
@@ -1781,8 +1798,8 @@ KI
 KI
 KI
 KI
-Hv
-PE
+LK
+kT
 aA
 aA
 aA
@@ -1796,8 +1813,8 @@ aA
 aA
 aA
 aA
-LG
-Hv
+cE
+LK
 KI
 ab
 ab
@@ -1816,13 +1833,13 @@ aa
 ab
 ab
 KI
-NT
-bz
-NT
-NT
+RA
+bx
+RA
+RA
 KI
-Hk
-PE
+Jm
+kT
 aA
 aA
 aA
@@ -1837,7 +1854,7 @@ iv
 FQ
 FQ
 MS
-Hv
+LK
 KI
 ab
 ab
@@ -1856,13 +1873,13 @@ aa
 ab
 ab
 KI
-cI
-hx
-CL
-Xk
-oO
-wv
-Nr
+Pz
+rg
+PC
+XF
+Lx
+hC
+Fk
 aA
 aA
 aA
@@ -1877,7 +1894,7 @@ aA
 aA
 aA
 qf
-Hv
+LK
 KI
 ab
 ab
@@ -1896,12 +1913,12 @@ aa
 ab
 ab
 KI
-Nw
-Nw
-wO
-wO
+vq
+cm
+SW
+SW
 KI
-Ak
+xi
 hy
 aA
 aA
@@ -1917,7 +1934,7 @@ aA
 aA
 aA
 qf
-Hv
+LK
 KI
 ab
 ab
@@ -1938,10 +1955,10 @@ ab
 KI
 KI
 KI
-Rb
+ji
 KI
 KI
-Hv
+LK
 hy
 aA
 aA
@@ -1957,7 +1974,7 @@ aA
 aA
 aA
 qf
-Hv
+LK
 KI
 ab
 ab
@@ -1978,8 +1995,8 @@ aa
 aa
 ab
 KI
-ow
-FP
+qY
+Cn
 KI
 pq
 hy
@@ -1997,7 +2014,7 @@ aA
 aA
 aA
 qf
-Hv
+LK
 KI
 ab
 ab
@@ -2018,8 +2035,8 @@ aa
 aa
 aa
 KI
-ow
-oq
+qY
+bU
 KI
 pq
 hy
@@ -2058,11 +2075,11 @@ aa
 aa
 aa
 KI
-qt
+hp
 KI
 KI
 pq
-hy
+lY
 aA
 aA
 aA
@@ -2076,8 +2093,8 @@ aA
 aA
 aA
 aA
-qb
-Hv
+Mc
+LK
 KI
 qG
 aa

--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -5,1162 +5,891 @@
 "ab" = (
 /turf/closed/mineral/random,
 /area/ruin/unpowered/no_grav)
-"ac" = (
-/turf/closed/wall,
-/area/ruin/space/has_grav/listeningstation)
-"ad" = (
-/obj/machinery/computer/message_monitor,
-/obj/machinery/airalarm/syndicate{
-	pixel_y = 24
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/paper/monitorkey,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/listeningstation)
 "ae" = (
-/obj/structure/table/reinforced,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/bookmanagement,
+/obj/structure/closet/crate/engineering/electrical,
+/obj/item/storage/toolbox/electrical,
+/obj/item/stock_parts/cell/hyper,
+/obj/item/stock_parts/cell/high,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/listeningstation)
-"af" = (
-/obj/structure/rack{
-	dir = 8
+"aA" = (
+/turf/open/floor/engine/hull{
+	initial_gas_mix = "o2=22;n2=82;TEMP=293.15";
+	name = "interior hull plating"
 	},
-/obj/item/clothing/mask/gas{
-	pixel_x = -3;
-	pixel_y = 3
+/area/ruin/space/has_grav/listeningstation)
+"aP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
+"bk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 5
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/item/clothing/mask/gas,
+/turf/closed/mineral/random,
+/area/ruin/unpowered/no_grav)
+"bz" = (
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "commsagent_hangar_door";
+	req_access = list(150);
+	name = "Hangar Doors"
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/listeningstation)
-"ag" = (
+"bD" = (
+/obj/docking_port/stationary{
+	dir = 2;
+	dwidth = 14;
+	height = 13;
+	id = "commsagent_home";
+	name = "Resupply Outpost";
+	roundstart_template = /datum/map_template/shuttle/ruin/syndicate_listening_ship;
+	width = 22
+	},
+/turf/open/floor/engine/hull{
+	initial_gas_mix = "o2=22;n2=82;TEMP=293.15";
+	name = "interior hull plating"
+	},
+/area/ruin/space/has_grav/listeningstation)
+"cw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
+"cI" = (
+/obj/machinery/firealarm/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/listeningstation)
+"cU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
+"dj" = (
+/obj/structure/cable,
+/obj/machinery/power/floodlight,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"dU" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"eQ" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/closet/crate{
+	name = "food crate"
+	},
+/obj/item/reagent_containers/food/drinks/waterbottle/large{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/drinks/waterbottle/large{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/drinks/waterbottle/large{
+	pixel_x = -2
+	},
+/obj/item/reagent_containers/food/drinks/waterbottle/large{
+	pixel_x = 5
+	},
+/obj/item/reagent_containers/food/drinks/waterbottle/large{
+	pixel_x = 1;
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/food/drinks/waterbottle/large{
+	pixel_x = 8;
+	pixel_y = -3
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
+"gi" = (
+/obj/effect/turf_decal/delivery,
+/obj/item/reagent_containers/food/snacks/canned/beans{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/snacks/canned/beans{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/snacks/canned/beans{
+	pixel_x = -2
+	},
+/obj/item/reagent_containers/food/snacks/canned/beans{
+	pixel_x = 5
+	},
+/obj/item/reagent_containers/food/snacks/canned/beans{
+	pixel_x = 1;
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/food/snacks/canned/beans{
+	pixel_x = 8;
+	pixel_y = -3
+	},
+/obj/structure/closet/crate{
+	name = "food crate"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/item/pizzabox/margherita,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
+"gF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
+"gM" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"hc" = (
+/obj/structure/railing,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"hx" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/listeningstation)
+"hy" = (
+/obj/structure/railing,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"ig" = (
+/obj/machinery/light/dim{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
+"iv" = (
+/obj/machinery/atmospherics/components/binary/valve/on/layer3,
+/turf/open/floor/engine/hull{
+	initial_gas_mix = "o2=22;n2=82;TEMP=293.15";
+	name = "interior hull plating"
+	},
+/area/ruin/space/has_grav/listeningstation)
+"iy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
+"jf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/mech_bay_recharge_port{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
+"jg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"kV" = (
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"mh" = (
+/obj/effect/turf_decal/delivery,
+/obj/item/reagent_containers/food/snacks/canned/beans{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/snacks/canned/beans{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/snacks/canned/beans{
+	pixel_x = -2
+	},
+/obj/item/reagent_containers/food/snacks/canned/beans{
+	pixel_x = 5
+	},
+/obj/item/reagent_containers/food/snacks/canned/beans{
+	pixel_x = 1;
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/food/snacks/canned/beans{
+	pixel_x = 8;
+	pixel_y = -3
+	},
+/obj/structure/closet/crate{
+	name = "food crate"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/pizzabox/margherita,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
+"mC" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"mN" = (
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/listeningstation)
+"nl" = (
+/obj/structure/railing,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"nn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/listeningstation)
+"oq" = (
+/obj/machinery/suit_storage_unit/open,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/listeningstation)
+"ou" = (
+/obj/item/flashlight/flare,
+/obj/item/flashlight/flare,
+/obj/item/flashlight/flare,
+/obj/item/flashlight/flare,
+/obj/item/flashlight/flare,
+/obj/item/flashlight,
+/obj/item/flashlight,
+/obj/item/shovel,
+/obj/item/pickaxe/drill,
+/obj/item/pickaxe/drill,
+/obj/effect/turf_decal/delivery,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/closet/crate,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
+"ow" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/listeningstation)
+"oO" = (
+/obj/machinery/door/airlock/hatch,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/listeningstation)
+"oP" = (
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/listeningstation)
+"pq" = (
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"qb" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"qf" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"qi" = (
+/obj/machinery/airalarm/syndicate/directional/south,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
+"qt" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/listeningstation)
+"qG" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer1{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/listeningstation)
+"rj" = (
+/obj/structure/cable,
 /turf/closed/wall/r_wall,
 /area/ruin/space/has_grav/listeningstation)
-"ah" = (
-/obj/machinery/computer/camera_advanced{
-	dir = 4
-	},
+"uL" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/item/radio/intercom{
-	freerange = 1;
-	name = "Syndicate Radio Intercom";
-	pixel_x = -30
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/listeningstation)
-"ai" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/listeningstation)
-"aj" = (
+"uT" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/listeningstation)
-"ak" = (
-/obj/machinery/telecomms/relay/preset/ruskie{
-	use_power = 0
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/listeningstation)
-"al" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/syndicate,
-/obj/item/flashlight{
-	pixel_y = -12
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/listeningstation)
-"am" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/listeningstation)
-"an" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	id_tag = "syndie_listeningpost_external";
-	req_access_txt = "150"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/listeningstation)
-"ao" = (
-/obj/machinery/light/small,
-/obj/structure/sign/warning/vacuum{
-	pixel_y = 32
-	},
+"va" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/listeningstation)
-"ap" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external{
-	id_tag = "syndie_listeningpost_external";
-	req_access_txt = "150"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/listeningstation)
-"aq" = (
-/obj/structure/curtain,
-/obj/machinery/shower{
-	pixel_y = 14
-	},
-/obj/machinery/light/small,
-/obj/item/soap,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/showroomfloor,
-/area/ruin/space/has_grav/listeningstation)
-"ar" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = 11
-	},
-/obj/structure/toilet{
-	pixel_y = 18
-	},
-/obj/structure/mirror{
-	pixel_x = 28
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/showroomfloor,
-/area/ruin/space/has_grav/listeningstation)
-"as" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/med_data/syndie{
-	dir = 4;
-	req_one_access = null
-	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/listeningstation)
-"at" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4;
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
+"wf" = (
+/obj/structure/railing{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"wl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/listeningstation)
-"au" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10;
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/listeningstation)
-"av" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 25
-	},
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/paper/fluff/ruins/listeningstation/reports/november,
-/obj/item/pen,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/listeningstation)
-"aw" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high/plus,
-/obj/item/stack/cable_coil{
-	pixel_x = 3;
-	pixel_y = -7
-	},
+"wv" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/syndicate{
-	dir = 4;
-	pixel_x = -24
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"wB" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "commsagent_hangar_warehouse"
 	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/listeningstation)
-"ax" = (
-/obj/machinery/light/small{
-	dir = 4
+"wO" = (
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/listeningstation)
+"xu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door{
+	id = "commsagent_hangar_warehouse";
+	name = "Hangar Warehouse";
+	req_access = list(150);
+	pixel_y = 24
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/machinery/button/door{
-	id = "syndie_listeningpost_external";
-	name = "External Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = 24;
-	req_access_txt = "150";
-	specialfunctions = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
+"ym" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
+"yV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"zK" = (
+/obj/structure/railing/corner{
+	dir = 4
 	},
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"Ak" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"An" = (
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/listeningstation)
-"ay" = (
-/obj/machinery/door/airlock{
-	name = "Toilet"
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/ruin/space/has_grav/listeningstation)
-"az" = (
-/obj/structure/filingcabinet,
-/obj/item/paper/fluff/ruins/listeningstation/reports/april,
-/obj/item/paper/fluff/ruins/listeningstation/reports/may,
-/obj/item/paper/fluff/ruins/listeningstation/reports/june,
-/obj/item/paper/fluff/ruins/listeningstation/reports/july,
-/obj/item/paper/fluff/ruins/listeningstation/reports/august,
-/obj/item/paper/fluff/ruins/listeningstation/reports/september,
-/obj/item/paper/fluff/ruins/listeningstation/reports/october,
-/obj/item/paper/fluff/ruins/listeningstation/receipt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/paper/fluff/ruins/listeningstation/odd_report,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"Aq" = (
+/obj/machinery/power/rtg/advanced,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/syndicate/directional/north,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/listeningstation)
+"BH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/listeningstation)
+"BU" = (
+/obj/machinery/power/rtg/advanced,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/listeningstation)
+"Cj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
+/obj/effect/spawner/lootdrop/whiteship_cere_ripley,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/listeningstation)
-"aA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+"CL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/listeningstation)
+"CU" = (
+/obj/structure/railing,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/listeningstation)
-"aB" = (
-/obj/structure/rack{
-	dir = 8
-	},
-/obj/item/multitool,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/listeningstation)
-"aC" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/item/mining_scanner,
-/obj/item/pickaxe,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/listeningstation)
-"aD" = (
-/obj/structure/table,
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = -2;
-	pixel_y = 6
-	},
-/obj/item/storage/box/donkpockets{
-	pixel_y = 3
-	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = 2
-	},
-/obj/item/reagent_containers/food/snacks/chocolatebar,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/random{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/ruin/space/has_grav/listeningstation)
-"aE" = (
-/obj/effect/turf_decal/stripes/line{
+"DN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
 	dir = 8
 	},
-/obj/structure/tank_dispenser/oxygen{
-	oxygentanks = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/listeningstation)
+"Es" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4;
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
 	},
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/iron,
 /area/ruin/space/has_grav/listeningstation)
-"aF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4;
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
+"Fr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/computer/mech_bay_power_console,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
+"FJ" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"FP" = (
+/obj/structure/rack,
+/obj/item/clothing/mask/gas/syndicate,
+/obj/item/tank/internals/oxygen,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/listeningstation)
+"FQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/open/floor/engine/hull{
+	initial_gas_mix = "o2=22;n2=82;TEMP=293.15";
+	name = "interior hull plating"
 	},
+/area/ruin/space/has_grav/listeningstation)
+"FZ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine/hull{
+	initial_gas_mix = "o2=22;n2=82;TEMP=293.15";
+	name = "interior hull plating"
+	},
+/area/ruin/space/has_grav/listeningstation)
+"Hf" = (
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
+"Hk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/syndicate/directional/north,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"Hn" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/listeningstation)
+"Hv" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"Ib" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/north,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"IF" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"IP" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/structure/railing/corner,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"JN" = (
+/obj/structure/closet/crate/radiation,
+/obj/item/clothing/head/radiation,
+/obj/item/clothing/suit/radiation,
+/obj/item/geiger_counter,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
+"KI" = (
 /turf/closed/wall/r_wall,
 /area/ruin/space/has_grav/listeningstation)
-"aG" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 8;
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/has_grav/listeningstation)
-"aH" = (
+"LF" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/bin,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/listeningstation)
-"aI" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/listeningstation)
-"aJ" = (
-/obj/machinery/washing_machine{
-	pixel_x = 4
-	},
-/obj/structure/window{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/listeningstation)
-"aK" = (
-/obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/machinery/door/airlock/hatch{
-	name = "Telecommunications";
-	req_access_txt = "150"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/listeningstation)
-"aL" = (
-/obj/item/bombcore/badmin{
-	anchored = 1;
-	invisibility = 100
-	},
-/turf/closed/wall,
-/area/ruin/space/has_grav/listeningstation)
-"aM" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/machinery/door/airlock/hatch{
-	name = "E.V.A. Equipment";
-	req_access_txt = "150"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/listeningstation)
-"aN" = (
-/obj/structure/table,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26
-	},
-/obj/machinery/microwave,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/listeningstation)
-"aO" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/closet/crate,
-/obj/item/stack/sheet/metal/twenty,
-/obj/item/stack/sheet/glass{
-	amount = 10
-	},
-/obj/item/stack/rods/ten,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/box/lights/bulbs,
-/obj/item/stack/sheet/mineral/plasma{
-	amount = 30
-	},
-/obj/item/stock_parts/cell/high/plus,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/listeningstation)
-"aP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/listeningstation)
-"aQ" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6;
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/listeningstation)
-"aR" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4;
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/machinery/door/airlock{
-	name = "Personal Quarters"
-	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/listeningstation)
-"aS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4;
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/listeningstation)
-"aT" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/listeningstation)
-"aU" = (
-/obj/machinery/airalarm/syndicate{
-	pixel_y = 24
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4;
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/effect/baseturf_helper/asteroid/airless,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/listeningstation)
-"aV" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4;
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/listeningstation)
-"aW" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/listeningstation)
-"aX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4;
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/listeningstation)
-"aY" = (
-/obj/machinery/vending/snack/random{
-	extended_inventory = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/random{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/listeningstation)
-"aZ" = (
-/obj/structure/table,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = -30
-	},
-/obj/item/reagent_containers/food/drinks/beer{
-	pixel_x = -4;
-	pixel_y = 14
-	},
-/obj/item/reagent_containers/food/drinks/beer{
-	pixel_x = 3;
-	pixel_y = 11
-	},
-/obj/item/storage/fancy/cigarettes/cigpack_syndicate{
-	pixel_x = -3
-	},
-/obj/item/lighter{
-	pixel_x = 7;
-	pixel_y = -3
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/listeningstation)
-"ba" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4;
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/listeningstation)
-"bb" = (
-/obj/effect/turf_decal/stripes/red/corner,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/airalarm/syndicate{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4;
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/listeningstation)
-"bc" = (
-/obj/machinery/light/small,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/emcloset/anchored,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/listeningstation)
-"bd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/listeningstation)
-"be" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -29
-	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/listeningstation)
-"bf" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1;
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/turf/open/floor/iron/white/corner,
-/area/ruin/space/has_grav/listeningstation)
-"bg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/turf/open/floor/iron/white/side,
-/area/ruin/space/has_grav/listeningstation)
-"bh" = (
-/obj/machinery/vending/cola/random{
-	extended_inventory = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white/corner{
-	dir = 8
-	},
-/area/ruin/space/has_grav/listeningstation)
-"bi" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5;
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/turf/open/floor/iron/grimy,
-/area/ruin/space/has_grav/listeningstation)
-"bj" = (
-/obj/machinery/computer/arcade/orion_trail,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/listeningstation)
-"bk" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/caution/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/listeningstation)
-"bl" = (
-/obj/machinery/syndicatebomb/self_destruct{
-	anchored = 1
-	},
-/obj/machinery/door/window/brigdoor{
-	dir = 8;
-	req_access_txt = "150"
-	},
-/obj/structure/sign/warning/explosives/alt{
-	pixel_x = 32
-	},
-/turf/open/floor/circuit/red,
-/area/ruin/space/has_grav/listeningstation)
-"bm" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/listeningstation)
-"bn" = (
-/obj/structure/sign/departments/medbay/alt,
-/turf/closed/wall,
-/area/ruin/space/has_grav/listeningstation)
-"bo" = (
-/obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/machinery/door/airlock/medical/glass{
-	name = "Medbay"
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/has_grav/listeningstation)
-"bp" = (
-/obj/effect/turf_decal/stripes/red/corner{
-	dir = 8
-	},
-/obj/machinery/door/airlock{
-	name = "Cabin"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/listeningstation)
-"bq" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/listeningstation)
-"br" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/power/apc/syndicate{
-	dir = 4;
-	name = "Syndicate Listening Post APC";
-	pixel_x = 24
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/listeningstation)
-"bs" = (
-/obj/structure/closet/crate/freezer,
-/obj/item/reagent_containers/blood/o_minus{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/blood/o_minus,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4;
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/turf/open/floor/iron/white/side{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 9
 	},
-/area/ruin/space/has_grav/listeningstation)
-"bt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9;
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/turf/open/floor/iron/white/side{
-	dir = 5
-	},
-/area/ruin/space/has_grav/listeningstation)
-"bu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/secure_closet/medical1{
-	req_access = null;
-	req_access_txt = "150"
-	},
-/turf/open/floor/iron/white,
-/area/ruin/space/has_grav/listeningstation)
-"bv" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/iron/grimy,
-/area/ruin/space/has_grav/listeningstation)
-"bw" = (
-/obj/structure/closet{
-	icon_door = "black";
-	name = "wardrobe"
-	},
-/obj/item/clothing/under/color/black{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/under/color/black{
-	pixel_x = 1;
-	pixel_y = -1
-	},
-/obj/item/clothing/head/soft/black{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/head/soft/black{
-	pixel_x = 1;
-	pixel_y = -1
-	},
-/obj/item/clothing/gloves/fingerless,
-/obj/item/clothing/shoes/sneakers/black{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/shoes/sneakers/black{
-	pixel_x = 1;
-	pixel_y = -1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/photo_album,
-/obj/machinery/light/small,
-/turf/open/floor/iron/grimy,
-/area/ruin/space/has_grav/listeningstation)
-"bx" = (
-/obj/effect/mob_spawn/human/lavaland_syndicate/comms/space{
-	assignedrole = "Space Syndicate";
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8;
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/turf/open/floor/iron/grimy,
-/area/ruin/space/has_grav/listeningstation)
-"by" = (
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/reagent_dispensers/fueltank,
-/obj/item/clothing/head/welding,
-/obj/item/weldingtool/largetank,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/listeningstation)
-"bz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/listeningstation)
-"bA" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/regular,
-/obj/item/clothing/neck/stethoscope,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white/side{
-	dir = 10
-	},
-/area/ruin/space/has_grav/listeningstation)
-"bB" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = 11
-	},
-/obj/machinery/iv_drip,
-/obj/machinery/light/small,
-/obj/machinery/airalarm/syndicate{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/iron/white/side{
-	dir = 6
-	},
-/area/ruin/space/has_grav/listeningstation)
-"bC" = (
-/obj/machinery/power/port_gen/pacman{
-	anchored = 1
-	},
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/wrench,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/listeningstation)
-"bD" = (
-/obj/structure/table/wood,
-/obj/item/ammo_box/magazine/m9mm,
-/obj/item/paper/fluff/ruins/listeningstation/briefing,
-/turf/open/floor/iron/grimy,
-/area/ruin/space/has_grav/listeningstation)
-"bF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/meter,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/listeningstation)
-"bH" = (
-/obj/machinery/atmospherics/components/unary/tank/air{
-	dir = 1
-	},
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/listeningstation)
-"bI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8;
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/listeningstation)
-"bJ" = (
-/obj/docking_port/stationary{
-	dir = 4;
-	dwidth = 6;
-	height = 7;
-	id = "caravansyndicate3_listeningpost";
-	name = "Syndicate Listening Post";
-	width = 15
+"LG" = (
+/obj/structure/railing{
+	dir = 1
 	},
-/obj/docking_port/stationary{
-	dir = 4;
-	dwidth = 4;
-	height = 5;
-	id = "caravansyndicate1_listeningpost";
-	name = "Syndicate Listening Post";
-	width = 9
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
 	},
-/turf/template_noop,
-/area/template_noop)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"Mi" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/poddoor{
+	id = "commsagent_hangar_door"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/listeningstation)
+"Mn" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/listeningstation)
+"Mp" = (
+/obj/structure/railing/corner,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"Mt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
+"MS" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"Na" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"Nb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/listeningstation)
+"Nr" = (
+/obj/structure/railing,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"Nw" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/listeningstation)
+"NT" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/listeningstation)
+"Pv" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"PE" = (
+/obj/structure/railing,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"Qm" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "commsagent_hangar_warehouse"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
+"QE" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"Rb" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/listeningstation)
+"Sd" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door{
+	id = "commsagent_hangar_warehouse";
+	name = "Hangar Warehouse";
+	req_access = list(150);
+	pixel_y = -24
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"SP" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"Vg" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"Xk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/listeningstation)
+"XA" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"XL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
+"XM" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"YO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/listeningstation)
+"YR" = (
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/listeningstation)
+"Zq" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"Zu" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/closed/wall/r_wall,
+/area/ruin/space/has_grav/listeningstation)
+"ZJ" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "commsagent_hangar_warehouse"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
 
 (1,1,1) = {"
 aa
@@ -1371,25 +1100,25 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+KI
+KI
+KI
+KI
+KI
+KI
+KI
+KI
+KI
+KI
+KI
+KI
+KI
+KI
+KI
+KI
+KI
+KI
+KI
 ab
 ab
 ab
@@ -1411,25 +1140,25 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+KI
+Hv
+pq
+pq
+pq
+pq
+pq
+pq
+Hv
+Hv
+Hv
+Hv
+yV
+Hv
+yV
+Hv
+pq
+pq
+KI
 ab
 ab
 ab
@@ -1447,29 +1176,29 @@ aa
 aa
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+KI
+KI
+KI
+KI
+KI
+gM
+Mp
+mC
+XA
+mC
+XA
+mC
+mC
+mC
+mC
+mC
+Na
+mC
+Na
+wf
+kV
+QE
+KI
 ab
 ab
 ab
@@ -1487,29 +1216,29 @@ aa
 aa
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+KI
+BU
+YO
+BH
+KI
+Ib
+CU
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+FZ
+Vg
+QE
+KI
 ab
 ab
 ab
@@ -1527,35 +1256,35 @@ aa
 aa
 aa
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+KI
+Aq
+nn
+DN
+Mn
+An
+nl
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+Vg
+QE
+KI
+KI
+KI
+KI
+KI
+KI
+KI
 ab
 ab
 ab
@@ -1567,35 +1296,35 @@ aa
 aa
 aa
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+KI
+BU
+oP
+Nb
+rj
+Hv
+hc
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+Vg
+gM
+KI
+va
+va
+cw
+Hf
+Hf
+KI
 ab
 ab
 ab
@@ -1607,35 +1336,35 @@ aa
 aa
 aa
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+KI
+KI
+mN
+Hn
+rj
+Hv
+hc
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+Zq
+Sd
+KI
+xu
+eQ
+eQ
+eQ
+Hf
+KI
 ab
 ab
 ab
@@ -1648,34 +1377,34 @@ aa
 aa
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+KI
+KI
+YR
+KI
+Hv
+hc
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+Vg
+FJ
+ZJ
+gF
+va
+Mt
+va
+va
+KI
 ab
 ab
 ab
@@ -1689,33 +1418,33 @@ aa
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+KI
+KI
+KI
+Hv
+hc
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+Vg
+FJ
+ZJ
+gF
+mh
+gi
+mh
+va
+KI
 ab
 ab
 ab
@@ -1731,31 +1460,31 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+KI
+pq
+hc
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+Es
+SP
+wB
+uT
+aP
+LF
+va
+iy
+KI
 ab
 ab
 ab
@@ -1771,31 +1500,31 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+KI
+Hv
+hc
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+IF
+Pv
+Qm
+cU
+ym
+XL
+va
+qi
+KI
 ab
 ab
 ab
@@ -1811,31 +1540,31 @@ ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+KI
+Hv
+IP
+bD
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+zK
+FJ
+ZJ
+gF
+ae
+ou
+JN
+va
+KI
 ab
 ab
 ab
@@ -1851,31 +1580,31 @@ ab
 ab
 ab
 ab
-ab
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+KI
+pq
+hc
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+Vg
+FJ
+ZJ
+gF
+va
+uL
+va
+va
+KI
 ab
 ab
 ab
@@ -1891,31 +1620,31 @@ ab
 ab
 ab
 ab
-ab
-ac
-aq
-ac
-aH
-aN
-aZ
-aD
-ac
-ac
-ac
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+KI
+Hv
+hc
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+Vg
+dU
+KI
+wl
+Cj
+jf
+Fr
+va
+KI
 ab
 ab
 ab
@@ -1931,31 +1660,31 @@ ab
 ab
 ab
 ab
-ab
-ac
-ar
-ay
-aI
-aP
-ba
-bj
-ac
-bv
-ac
-ac
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+KI
+dj
+hc
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+LG
+dj
+KI
+va
+va
+ig
+va
+va
+KI
 ab
 ab
 ab
@@ -1971,31 +1700,31 @@ ab
 ab
 ab
 ab
-ac
-ac
-ac
-ac
-aJ
-aQ
-bb
-bk
-bp
-bi
-bw
-ac
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+KI
+Hv
+PE
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+LG
+Hv
+KI
+KI
+KI
+KI
+KI
+KI
+KI
 ab
 ab
 ab
@@ -2010,26 +1739,26 @@ ab
 ab
 ab
 ab
-ac
-ac
-ah
-as
-ac
-ac
-aR
-ac
-bl
-ac
-bx
-bD
-ac
 ab
-ab
-ab
-ab
-ab
-ab
-ab
+KI
+Hv
+PE
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+LG
+Hv
+KI
 ab
 ab
 ab
@@ -2046,30 +1775,30 @@ ab
 aa
 ab
 ab
-ab
-ab
-ab
-ab
-ac
-ad
-ai
-at
-az
-ac
-aS
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ab
-ab
-ab
-ab
-ab
-ab
+KI
+KI
+KI
+KI
+KI
+KI
+Hv
+PE
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+LG
+Hv
+KI
 ab
 ab
 ab
@@ -2086,30 +1815,30 @@ ab
 aa
 ab
 ab
-ab
-ab
-ab
-ab
-ac
-ae
-aj
-au
+KI
+NT
+bz
+NT
+NT
+KI
+Hk
+PE
 aA
-aK
-aT
-bc
-ac
-bq
-by
-aO
-bC
-ac
-ab
-ab
-ab
-ab
-ab
-ab
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+iv
+FQ
+FQ
+MS
+Hv
+KI
 ab
 ab
 ab
@@ -2126,30 +1855,30 @@ ab
 aa
 ab
 ab
-ab
-ab
-ab
-ab
-ac
-ac
-ak
-av
-aB
-ac
-aU
-bd
-bm
-br
-bz
-bF
-bH
-ac
-ab
-ab
-ab
-ab
-ab
-ab
+KI
+cI
+hx
+CL
+Xk
+oO
+wv
+Nr
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+qf
+Hv
+KI
 ab
 ab
 ab
@@ -2166,30 +1895,30 @@ aa
 aa
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ac
-ac
-ac
-ac
-aL
-aV
-be
-ac
-ac
-ac
-ac
-ac
-ac
-ab
-ab
-ab
-ab
-ab
-ab
+KI
+Nw
+Nw
+wO
+wO
+KI
+Ak
+hy
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+qf
+Hv
+KI
 ab
 ab
 ab
@@ -2206,30 +1935,30 @@ aa
 aa
 aa
 ab
-ab
-ab
-ab
-ab
-ac
-ac
-al
-aw
-aC
-ac
-aW
-bf
-bn
-bs
-bA
-ac
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+KI
+KI
+KI
+Rb
+KI
+KI
+Hv
+hy
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+qf
+Hv
+KI
 ab
 ab
 ab
@@ -2248,28 +1977,28 @@ aa
 aa
 aa
 ab
-ab
-ab
-ac
-af
-am
-ax
-bI
-aM
-aX
-bg
-bo
-bt
-bB
-ac
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+KI
+ow
+FP
+KI
+pq
+hy
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+qf
+Hv
+KI
 ab
 ab
 ab
@@ -2288,29 +2017,29 @@ aa
 aa
 aa
 aa
-ab
-ab
-ac
-ac
-an
-ac
-aE
-ac
-aY
-bh
-ac
-bu
-ac
-ac
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+KI
+ow
+oq
+KI
+pq
+hy
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+XM
+jg
+Zu
+bk
 ab
 aa
 aa
@@ -2328,29 +2057,29 @@ aa
 aa
 aa
 aa
-ab
-ab
-ab
-ag
-ao
-ag
-aF
-ag
-ac
-ac
-ac
-ac
-ac
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
+KI
+qt
+KI
+KI
+pq
+hy
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+qb
+Hv
+KI
+qG
 aa
 aa
 aa
@@ -2370,26 +2099,26 @@ aa
 aa
 aa
 aa
-aa
-ag
-ap
-ag
-aG
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
+KI
+KI
+KI
+Mi
+Mi
+Mi
+Mi
+Mi
+Mi
+Mi
+Mi
+Mi
+Mi
+Mi
+Mi
+Mi
+KI
+KI
+KI
 aa
 aa
 aa
@@ -2412,7 +2141,6 @@ aa
 aa
 aa
 aa
-bJ
 aa
 aa
 aa
@@ -2422,11 +2150,12 @@ aa
 aa
 aa
 aa
-ab
-ab
-ab
-ab
-ab
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa

--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -5,13 +5,10 @@
 "ab" = (
 /turf/closed/mineral/random,
 /area/ruin/unpowered/no_grav)
-"al" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "commsagent_hangar_warehouse"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/turf/open/floor/iron/dark,
+"as" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/listeningstation)
 "aA" = (
 /turf/open/floor/engine/hull{
@@ -25,24 +22,19 @@
 	},
 /turf/closed/mineral/random,
 /area/ruin/unpowered/no_grav)
-"bl" = (
-/obj/structure/cable,
+"bq" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm/directional/south,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
+/obj/machinery/airalarm/syndicate/directional/north,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/listeningstation)
-"bx" = (
-/obj/structure/table/reinforced,
-/obj/machinery/button/door{
-	id = "commsagent_hangar_door";
-	req_access = list(150);
-	name = "Hangar Doors"
+"bw" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium/red,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/listeningstation)
 "bD" = (
 /obj/docking_port/stationary{
@@ -59,42 +51,16 @@
 	name = "interior hull plating"
 	},
 /area/ruin/space/has_grav/listeningstation)
-"bU" = (
-/obj/machinery/suit_storage_unit/open,
+"ct" = (
+/obj/structure/railing,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/listeningstation)
-"ca" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/computer/mech_bay_power_console,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/listeningstation)
-"cm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/dim{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space/has_grav/listeningstation)
-"cE" = (
-/obj/structure/railing{
-	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/space/has_grav/listeningstation)
-"db" = (
-/obj/machinery/light/dim{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/listeningstation)
 "dj" = (
 /obj/structure/cable,
@@ -102,143 +68,33 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/listeningstation)
-"fg" = (
+"eH" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/listeningstation)
-"hc" = (
-/obj/structure/railing,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/listeningstation)
-"hp" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
+"eW" = (
+/obj/machinery/door/airlock/hatch,
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/listeningstation)
-"hy" = (
-/obj/structure/railing,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/listeningstation)
-"hC" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/listeningstation)
-"hY" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/door{
-	id = "commsagent_hangar_warehouse";
-	name = "Hangar Warehouse";
-	req_access = list(150);
-	pixel_y = -24
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/listeningstation)
+"fG" = (
+/obj/structure/railing{
+	dir = 1
 	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/listeningstation)
-"iv" = (
-/obj/machinery/atmospherics/components/binary/valve/on/layer3,
-/turf/open/floor/engine/hull{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15";
-	name = "interior hull plating"
-	},
-/area/ruin/space/has_grav/listeningstation)
-"iy" = (
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/listeningstation)
-"jg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/listeningstation)
-"ji" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/listeningstation)
-"jI" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/listeningstation)
-"kT" = (
-/obj/structure/railing,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/listeningstation)
-"kV" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/listeningstation)
-"lY" = (
-/obj/structure/railing,
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/listeningstation)
-"mi" = (
-/obj/machinery/airalarm/syndicate/directional/south,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/listeningstation)
-"mC" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/listeningstation)
-"mN" = (
-/obj/machinery/power/smes/engineering,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/listeningstation)
-"mV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/listeningstation)
-"ni" = (
+"fN" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/crate{
 	name = "food crate"
@@ -268,6 +124,166 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/listeningstation)
+"gh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/computer/mech_bay_power_console,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
+"hc" = (
+/obj/structure/railing,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"hy" = (
+/obj/structure/railing,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"io" = (
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "commsagent_hangar_door";
+	req_access = list(150);
+	name = "Hangar Doors"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/listeningstation)
+"iv" = (
+/obj/machinery/atmospherics/components/binary/valve/on/layer3,
+/turf/open/floor/engine/hull{
+	initial_gas_mix = "o2=22;n2=82;TEMP=293.15";
+	name = "interior hull plating"
+	},
+/area/ruin/space/has_grav/listeningstation)
+"iR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
+"ja" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
+"jg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"jt" = (
+/obj/machinery/light/dim{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
+"jC" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/listeningstation)
+"jF" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"ky" = (
+/obj/structure/rack,
+/obj/item/clothing/mask/gas/syndicate,
+/obj/item/tank/internals/oxygen,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/listeningstation)
+"kG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
+"kV" = (
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"ly" = (
+/obj/item/flashlight/flare,
+/obj/item/flashlight/flare,
+/obj/item/flashlight/flare,
+/obj/item/flashlight/flare,
+/obj/item/flashlight/flare,
+/obj/item/flashlight,
+/obj/item/flashlight,
+/obj/item/shovel,
+/obj/item/pickaxe/drill,
+/obj/item/pickaxe/drill,
+/obj/effect/turf_decal/delivery,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/closet/crate,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
+"lI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"mC" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"mE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
+"mN" = (
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/listeningstation)
+"nf" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
 "nl" = (
 /obj/structure/railing,
 /obj/structure/cable,
@@ -280,13 +296,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/listeningstation)
-"oa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/broken{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/listeningstation)
 "oP" = (
 /obj/machinery/power/terminal{
@@ -322,13 +331,35 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/listeningstation)
+"qA" = (
+/obj/structure/railing,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
 "qG" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer1{
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/listeningstation)
-"qW" = (
+"rj" = (
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
+/area/ruin/space/has_grav/listeningstation)
+"rM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
+"su" = (
 /obj/structure/closet/crate/engineering/electrical,
 /obj/item/storage/toolbox/electrical,
 /obj/item/stock_parts/cell/hyper,
@@ -336,39 +367,12 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/listeningstation)
-"qY" = (
+"tt" = (
+/obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/listeningstation)
-"rb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/listeningstation)
-"rg" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/listeningstation)
-"rj" = (
-/obj/structure/cable,
-/turf/closed/wall/r_wall,
-/area/ruin/space/has_grav/listeningstation)
-"rW" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "commsagent_hangar_warehouse"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/listeningstation)
-"sE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/listeningstation)
-"sW" = (
+"uh" = (
 /obj/effect/turf_decal/delivery,
 /obj/item/reagent_containers/food/snacks/canned/beans{
 	pixel_x = -5;
@@ -402,23 +406,56 @@
 /obj/item/pizzabox/margherita,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/listeningstation)
-"tj" = (
+"uj" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/listeningstation)
-"vq" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space/has_grav/listeningstation)
-"vH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 5
+"ur" = (
+/obj/effect/turf_decal/delivery,
+/obj/item/reagent_containers/food/snacks/canned/beans{
+	pixel_x = -5;
+	pixel_y = 3
 	},
+/obj/item/reagent_containers/food/snacks/canned/beans{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/snacks/canned/beans{
+	pixel_x = -2
+	},
+/obj/item/reagent_containers/food/snacks/canned/beans{
+	pixel_x = 5
+	},
+/obj/item/reagent_containers/food/snacks/canned/beans{
+	pixel_x = 1;
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/food/snacks/canned/beans{
+	pixel_x = 8;
+	pixel_y = -3
+	},
+/obj/structure/closet/crate{
+	name = "food crate"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/pizzabox/margherita,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
+"vp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
+"vx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"wn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
+/obj/effect/spawner/lootdrop/whiteship_cere_ripley,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/listeningstation)
 "wB" = (
@@ -428,19 +465,16 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/listeningstation)
-"wD" = (
-/obj/structure/cable,
+"wR" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/listeningstation)
-"xi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/listeningstation)
-"zC" = (
+"yt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/listeningstation)
 "zK" = (
@@ -459,6 +493,14 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/listeningstation)
+"Aa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/mech_bay_recharge_port{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
 "An" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -470,14 +512,15 @@
 /obj/machinery/power/rtg/advanced,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/syndicate/directional/north,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/listeningstation)
-"Cn" = (
-/obj/structure/rack,
-/obj/item/clothing/mask/gas/syndicate,
-/obj/item/tank/internals/oxygen,
+"Bc" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/listeningstation)
 "CU" = (
 /obj/structure/railing,
@@ -498,36 +541,34 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/listeningstation)
-"En" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/listeningstation)
-"Fk" = (
-/obj/structure/railing,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/listeningstation)
-"Fm" = (
+"Es" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/listeningstation)
-"FD" = (
+"Ex" = (
+/obj/machinery/power/rtg/advanced,
+/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/broken{
-	dir = 8
-	},
 /turf/open/floor/plating,
+/area/ruin/space/has_grav/listeningstation)
+"EJ" = (
+/obj/machinery/airalarm/syndicate/directional/south,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
+"FI" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"FM" = (
+/turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/listeningstation)
 "FQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -535,6 +576,28 @@
 	initial_gas_mix = "o2=22;n2=82;TEMP=293.15";
 	name = "interior hull plating"
 	},
+/area/ruin/space/has_grav/listeningstation)
+"Gw" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "commsagent_hangar_warehouse"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
+"GH" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/listeningstation)
+"Hm" = (
+/obj/machinery/firealarm/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/listeningstation)
 "Hn" = (
 /obj/structure/cable,
@@ -548,17 +611,6 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/listeningstation)
-"Ie" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/listeningstation)
-"IO" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/listeningstation)
 "IP" = (
@@ -576,99 +628,74 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/listeningstation)
-"IY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/listeningstation)
-"Jm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/syndicate/directional/north,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/listeningstation)
-"Kl" = (
-/obj/effect/turf_decal/delivery,
-/obj/item/reagent_containers/food/snacks/canned/beans{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/food/snacks/canned/beans{
-	pixel_x = 2;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/food/snacks/canned/beans{
-	pixel_x = -2
-	},
-/obj/item/reagent_containers/food/snacks/canned/beans{
-	pixel_x = 5
-	},
-/obj/item/reagent_containers/food/snacks/canned/beans{
-	pixel_x = 1;
-	pixel_y = -3
-	},
-/obj/item/reagent_containers/food/snacks/canned/beans{
-	pixel_x = 8;
-	pixel_y = -3
-	},
-/obj/structure/closet/crate{
-	name = "food crate"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/pizzabox/margherita,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/listeningstation)
-"KG" = (
-/obj/item/flashlight/flare,
-/obj/item/flashlight/flare,
-/obj/item/flashlight/flare,
-/obj/item/flashlight/flare,
-/obj/item/flashlight/flare,
-/obj/item/flashlight,
-/obj/item/flashlight,
-/obj/item/shovel,
-/obj/item/pickaxe/drill,
-/obj/item/pickaxe/drill,
-/obj/effect/turf_decal/delivery,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/closet/crate,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/listeningstation)
-"KI" = (
-/turf/closed/wall/r_wall,
-/area/ruin/space/has_grav/listeningstation)
-"KP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/obj/effect/spawner/lootdrop/whiteship_cere_ripley,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/listeningstation)
-"Lx" = (
-/obj/machinery/door/airlock/hatch,
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space/has_grav/listeningstation)
-"LK" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/listeningstation)
-"Mc" = (
+"Jb" = (
 /obj/structure/railing{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"Je" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door{
+	id = "commsagent_hangar_warehouse";
+	name = "Hangar Warehouse";
+	req_access = list(150);
+	pixel_y = -24
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"Jf" = (
+/obj/structure/closet/crate/radiation,
+/obj/item/clothing/head/radiation,
+/obj/item/clothing/suit/radiation,
+/obj/item/geiger_counter,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
+"JU" = (
+/obj/structure/railing,
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"Kt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"KI" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/has_grav/listeningstation)
+"KM" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"Mg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/listeningstation)
 "Mi" = (
 /obj/structure/fans/tiny,
@@ -697,12 +724,21 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/listeningstation)
+"MJ" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
 "MS" = (
 /obj/structure/railing{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 9
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
@@ -717,15 +753,95 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/listeningstation)
-"Ne" = (
+"NB" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/mech_bay_recharge_port{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/listeningstation)
-"Nx" = (
+"Pt" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/listeningstation)
+"Qu" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"QE" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"QZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/dim{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/listeningstation)
+"Rw" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine/hull{
+	initial_gas_mix = "o2=22;n2=82;TEMP=293.15";
+	name = "interior hull plating"
+	},
+/area/ruin/space/has_grav/listeningstation)
+"SM" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"Te" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/listeningstation)
+"Tk" = (
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/listeningstation)
+"Tp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/listeningstation)
+"Vf" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
+"Vg" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"VG" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/listeningstation)
+"Xu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/listeningstation)
+"XH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/button/door{
 	id = "commsagent_hangar_warehouse";
@@ -738,135 +854,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/listeningstation)
-"Os" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/listeningstation)
-"OD" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/listeningstation)
-"OR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 9
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/listeningstation)
-"Pz" = (
-/obj/machinery/firealarm/directional/north,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space/has_grav/listeningstation)
-"PC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space/has_grav/listeningstation)
-"Qz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/listeningstation)
-"QE" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/listeningstation)
-"RA" = (
-/obj/structure/table/reinforced,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space/has_grav/listeningstation)
-"SF" = (
-/obj/structure/closet/crate/radiation,
-/obj/item/clothing/head/radiation,
-/obj/item/clothing/suit/radiation,
-/obj/item/geiger_counter,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/listeningstation)
-"SW" = (
-/turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space/has_grav/listeningstation)
-"To" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/listeningstation)
-"TR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/listeningstation)
-"Uz" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine/hull{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15";
-	name = "interior hull plating"
-	},
-/area/ruin/space/has_grav/listeningstation)
-"UB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/listeningstation)
-"Vg" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/listeningstation)
-"VY" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/listeningstation)
-"XF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space/has_grav/listeningstation)
 "XM" = (
 /obj/structure/railing{
 	dir = 1
@@ -877,11 +864,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/listeningstation)
-"XU" = (
-/obj/machinery/power/rtg/advanced,
-/obj/structure/cable,
+"Yt" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/syndicate/directional/north,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/listeningstation)
+"YM" = (
+/obj/machinery/suit_storage_unit/open,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/listeningstation)
 "YR" = (
@@ -890,6 +882,14 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
+/area/ruin/space/has_grav/listeningstation)
+"Zg" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "commsagent_hangar_warehouse"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/listeningstation)
 "Zq" = (
 /obj/structure/railing{
@@ -1158,21 +1158,21 @@ ab
 ab
 ab
 KI
-LK
+wR
 pq
 pq
 pq
 pq
 pq
 pq
-LK
-LK
-LK
-LK
-sE
-LK
-sE
-LK
+wR
+wR
+wR
+wR
+Kt
+wR
+Kt
+wR
 pq
 pq
 KI
@@ -1198,21 +1198,21 @@ KI
 KI
 KI
 KI
-wD
+Es
 Mp
+MJ
+nf
+MJ
+nf
+MJ
+MJ
+MJ
+MJ
+MJ
+FI
+MJ
+FI
 mC
-To
-mC
-To
-mC
-mC
-mC
-mC
-mC
-OD
-mC
-OD
-Os
 kV
 QE
 KI
@@ -1234,8 +1234,8 @@ aa
 ab
 ab
 KI
-Aq
-FD
+Ex
+Xu
 nn
 KI
 Ib
@@ -1252,8 +1252,8 @@ aA
 aA
 aA
 aA
-Uz
-VY
+Rw
+Vg
 QE
 KI
 ab
@@ -1274,8 +1274,8 @@ aa
 aa
 ab
 KI
-XU
-TR
+Aq
+as
 DN
 Mn
 An
@@ -1293,7 +1293,7 @@ aA
 aA
 aA
 aA
-VY
+Vg
 QE
 KI
 KI
@@ -1314,11 +1314,11 @@ aa
 aa
 ab
 KI
-Aq
+Ex
 oP
 Nb
 rj
-LK
+wR
 hc
 aA
 aA
@@ -1333,14 +1333,14 @@ aA
 aA
 aA
 aA
-VY
-wD
+Vg
+Es
 KI
-Ie
-Ie
-oa
-iy
-iy
+Vf
+Vf
+mE
+FM
+FM
 KI
 ab
 ab
@@ -1358,7 +1358,7 @@ KI
 mN
 Hn
 rj
-LK
+wR
 hc
 aA
 aA
@@ -1374,13 +1374,13 @@ aA
 aA
 aA
 Zq
-hY
+Je
 KI
-Nx
-ni
-ni
-ni
-iy
+XH
+fN
+fN
+fN
+FM
 KI
 ab
 ab
@@ -1398,7 +1398,7 @@ KI
 KI
 YR
 KI
-LK
+wR
 hc
 aA
 aA
@@ -1413,14 +1413,14 @@ aA
 aA
 aA
 aA
-VY
-Fm
+Vg
+VG
 wB
-En
-Ie
-fg
-Ie
-Ie
+eH
+Vf
+NB
+Vf
+Vf
 KI
 ab
 ab
@@ -1438,7 +1438,7 @@ ab
 KI
 KI
 KI
-LK
+wR
 hc
 aA
 aA
@@ -1453,14 +1453,14 @@ aA
 aA
 aA
 aA
-VY
-Fm
+Vg
+VG
 wB
-En
-Kl
-sW
-Kl
-Ie
+eH
+ur
+uh
+ur
+Vf
 KI
 ab
 ab
@@ -1493,14 +1493,14 @@ aA
 aA
 aA
 aA
-Vg
-jI
-al
-UB
-rb
-OR
-Ie
-mV
+Jb
+jF
+Zg
+ja
+uj
+Yt
+Vf
+kG
 KI
 ab
 ab
@@ -1518,7 +1518,7 @@ ab
 ab
 ab
 KI
-LK
+wR
 hc
 aA
 aA
@@ -1534,13 +1534,13 @@ aA
 aA
 aA
 qb
-IO
-rW
-tj
-zC
-vH
-Ie
-mi
+Qu
+Gw
+yt
+vp
+rM
+Vf
+EJ
 KI
 ab
 ab
@@ -1558,7 +1558,7 @@ ab
 ab
 ab
 KI
-LK
+wR
 IP
 bD
 aA
@@ -1574,13 +1574,13 @@ aA
 aA
 aA
 zK
-Fm
+VG
 wB
-En
-qW
-KG
-SF
-Ie
+eH
+su
+ly
+Jf
+Vf
 KI
 ab
 ab
@@ -1613,14 +1613,14 @@ aA
 aA
 aA
 aA
-VY
-Fm
+Vg
+VG
 wB
-En
-Ie
-Qz
-Ie
-Ie
+eH
+Vf
+Bc
+Vf
+Vf
 KI
 ab
 ab
@@ -1638,7 +1638,7 @@ ab
 ab
 ab
 KI
-LK
+wR
 hc
 aA
 aA
@@ -1653,14 +1653,14 @@ aA
 aA
 aA
 aA
-VY
-bl
+Vg
+SM
 KI
-IY
-KP
-Ne
-ca
-Ie
+iR
+wn
+Aa
+gh
+Vf
 KI
 ab
 ab
@@ -1693,14 +1693,14 @@ aA
 aA
 aA
 aA
-cE
+MS
 dj
 KI
-Ie
-Ie
-db
-Ie
-Ie
+Vf
+Vf
+jt
+Vf
+Vf
 KI
 ab
 ab
@@ -1718,8 +1718,8 @@ ab
 ab
 ab
 KI
-LK
-kT
+wR
+ct
 aA
 aA
 aA
@@ -1733,8 +1733,8 @@ aA
 aA
 aA
 aA
-cE
-LK
+MS
+wR
 KI
 KI
 KI
@@ -1758,8 +1758,8 @@ ab
 ab
 ab
 KI
-LK
-kT
+wR
+ct
 aA
 aA
 aA
@@ -1773,8 +1773,8 @@ aA
 aA
 aA
 aA
-cE
-LK
+MS
+wR
 KI
 ab
 ab
@@ -1798,8 +1798,8 @@ KI
 KI
 KI
 KI
-LK
-kT
+wR
+ct
 aA
 aA
 aA
@@ -1813,8 +1813,8 @@ aA
 aA
 aA
 aA
-cE
-LK
+MS
+wR
 KI
 ab
 ab
@@ -1833,13 +1833,13 @@ aa
 ab
 ab
 KI
-RA
-bx
-RA
-RA
+tt
+io
+tt
+tt
 KI
-Jm
-kT
+bq
+ct
 aA
 aA
 aA
@@ -1850,11 +1850,11 @@ aA
 aA
 aA
 aA
-iv
-FQ
-FQ
+aA
+aA
+aA
 MS
-LK
+wR
 KI
 ab
 ab
@@ -1873,13 +1873,13 @@ aa
 ab
 ab
 KI
-Pz
-rg
-PC
-XF
-Lx
-hC
-Fk
+Hm
+Pt
+Tp
+Mg
+eW
+lI
+qA
 aA
 aA
 aA
@@ -1890,11 +1890,11 @@ aA
 aA
 aA
 aA
-aA
-aA
-aA
-qf
-LK
+iv
+FQ
+FQ
+KM
+wR
 KI
 ab
 ab
@@ -1913,12 +1913,12 @@ aa
 ab
 ab
 KI
-vq
-cm
-SW
-SW
+jC
+QZ
+Tk
+Tk
 KI
-xi
+vx
 hy
 aA
 aA
@@ -1934,7 +1934,7 @@ aA
 aA
 aA
 qf
-LK
+wR
 KI
 ab
 ab
@@ -1955,10 +1955,10 @@ ab
 KI
 KI
 KI
-ji
+bw
 KI
 KI
-LK
+wR
 hy
 aA
 aA
@@ -1974,7 +1974,7 @@ aA
 aA
 aA
 qf
-LK
+wR
 KI
 ab
 ab
@@ -1995,8 +1995,8 @@ aa
 aa
 ab
 KI
-qY
-Cn
+Te
+ky
 KI
 pq
 hy
@@ -2014,7 +2014,7 @@ aA
 aA
 aA
 qf
-LK
+wR
 KI
 ab
 ab
@@ -2035,8 +2035,8 @@ aa
 aa
 aa
 KI
-qY
-bU
+Te
+YM
 KI
 pq
 hy
@@ -2075,11 +2075,11 @@ aa
 aa
 aa
 KI
-hp
+GH
 KI
 KI
 pq
-lY
+JU
 aA
 aA
 aA
@@ -2093,8 +2093,8 @@ aA
 aA
 aA
 aA
-Mc
-LK
+fG
+wR
 KI
 qG
 aa
@@ -2120,19 +2120,19 @@ ab
 KI
 KI
 KI
-Mi
-Mi
-Mi
-Mi
-Mi
-Mi
-Mi
-Mi
-Mi
-Mi
-Mi
-Mi
-Mi
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
+aA
 KI
 KI
 KI
@@ -2159,21 +2159,21 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+KI
+Mi
+Mi
+Mi
+Mi
+Mi
+Mi
+Mi
+Mi
+Mi
+Mi
+Mi
+Mi
+Mi
+KI
 aa
 aa
 aa

--- a/_maps/shuttles/ruin_syndicate_listening_ship.dmm
+++ b/_maps/shuttles/ruin_syndicate_listening_ship.dmm
@@ -1,0 +1,1301 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ay" = (
+/obj/machinery/computer/monitor{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/commsagent)
+"aA" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/shuttle/commsagent)
+"bf" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/shuttle/commsagent)
+"bo" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer3,
+/turf/open/floor/iron,
+/area/shuttle/commsagent)
+"dD" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/computer/arcade/orion_trail{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/shuttle/commsagent)
+"eq" = (
+/obj/machinery/button/door{
+	id = "commsagent_bolts";
+	name = "External Airlock Bolt Controls";
+	normaldoorcontrol = 1;
+	pixel_x = -6;
+	specialfunctions = 4;
+	pixel_y = 24;
+	req_access = list(150)
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/shuttle/commsagent)
+"fh" = (
+/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
+/turf/open/floor/plating,
+/area/shuttle/commsagent)
+"fp" = (
+/obj/structure/shuttle/engine/propulsion/burst/left{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/commsagent)
+"fB" = (
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/commsagent)
+"fK" = (
+/obj/machinery/computer/message_monitor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/commsagent)
+"gl" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/shuttle/commsagent)
+"gX" = (
+/obj/structure/cable,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/shuttle/commsagent)
+"hj" = (
+/obj/machinery/firealarm/directional/south,
+/obj/machinery/airalarm/syndicate/directional/north,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/mirror{
+	pixel_x = 32
+	},
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/structure/sink{
+	pixel_y = 24
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/showroomfloor,
+/area/shuttle/commsagent)
+"hu" = (
+/obj/effect/turf_decal/syndicateemblem/bottom/left{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/commsagent)
+"if" = (
+/obj/machinery/door/airlock{
+	name = "Dormitory"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/iron/grimy,
+/area/shuttle/commsagent)
+"ir" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/fancy/cigarettes/cigpack_syndicate,
+/obj/item/lighter,
+/turf/open/floor/iron,
+/area/shuttle/commsagent)
+"kW" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/shuttle/commsagent)
+"lt" = (
+/obj/structure/cable,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/shuttle/commsagent)
+"lA" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/syndicateemblem/top/middle{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/commsagent)
+"mC" = (
+/turf/open/floor/iron,
+/area/shuttle/commsagent)
+"nj" = (
+/obj/machinery/airalarm/syndicate/directional/south,
+/obj/machinery/vending/cola/red{
+	onstation = 0
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/commsagent)
+"oA" = (
+/obj/machinery/vending/snack{
+	onstation = 0
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/commsagent)
+"ql" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/shuttle/commsagent)
+"qx" = (
+/obj/structure/shuttle/engine/propulsion/burst/right{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/commsagent)
+"qT" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/shuttle/commsagent)
+"se" = (
+/obj/structure/closet/crate,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/soap/syndie,
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bucket,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/commsagent)
+"sA" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/commsagent)
+"to" = (
+/obj/structure/table/optable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white,
+/area/shuttle/commsagent)
+"tZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/commsagent)
+"uz" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
+/obj/effect/turf_decal/syndicateemblem/middle/left{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/commsagent)
+"uB" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 1
+	},
+/obj/structure/reagent_dispensers/watertank/high,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/commsagent)
+"uW" = (
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/external{
+	id_tag = "commsagent_bolts"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/shuttle/commsagent)
+"vd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/grimy,
+/area/shuttle/commsagent)
+"vn" = (
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/external{
+	id_tag = "commsagent_bolts"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/commsagent)
+"vz" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Bridge"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
+/obj/machinery/door/firedoor,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/commsagent)
+"vD" = (
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/commsagent)
+"vK" = (
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/shuttle/engine/heater{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/commsagent)
+"wV" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/shuttle/commsagent)
+"xv" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/drinks/beer,
+/obj/item/reagent_containers/food/drinks/beer{
+	pixel_x = 6;
+	pixel_y = 3;
+	list_reagents = list(/datum/reagent/consumable/ethanol/beer = 15)
+	},
+/turf/open/floor/iron,
+/area/shuttle/commsagent)
+"xx" = (
+/obj/item/storage/toolbox/syndicate,
+/obj/machinery/light,
+/obj/structure/closet/crate/engineering,
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 25
+	},
+/obj/item/stack/sheet/mineral/plastitanium{
+	amount = 15
+	},
+/obj/item/stack/sheet/glass{
+	amount = 25
+	},
+/obj/item/stack/sheet/metal{
+	amount = 35
+	},
+/obj/item/storage/belt/utility,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/toolbox/electrical,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/commsagent)
+"xT" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 1
+	},
+/obj/effect/turf_decal/syndicateemblem/middle/right{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/commsagent)
+"xU" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/shuttle/commsagent)
+"xW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/shuttle/commsagent)
+"yf" = (
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 5
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/iron/grimy,
+/area/shuttle/commsagent)
+"yx" = (
+/obj/structure/closet/syndicate,
+/obj/item/clothing/head/hos/beret/syndicate,
+/obj/item/clothing/head/hos/syndicate,
+/obj/item/clothing/under/syndicate,
+/obj/item/clothing/under/syndicate/combat,
+/obj/item/clothing/under/syndicate/camo,
+/turf/open/floor/iron/grimy,
+/area/shuttle/commsagent)
+"yU" = (
+/obj/machinery/power/smes{
+	charge = 5e+006
+	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/shuttle/commsagent)
+"yX" = (
+/obj/structure/table/reinforced,
+/obj/machinery/microwave,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron,
+/area/shuttle/commsagent)
+"zk" = (
+/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
+/obj/machinery/door/poddoor/shutters{
+	id = "commsagent_windows"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/shuttle/commsagent)
+"zr" = (
+/obj/machinery/computer/shuttle/listening_ship{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/commsagent)
+"zU" = (
+/obj/machinery/computer/camera_advanced/syndie,
+/obj/structure/cable,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/commsagent)
+"Bb" = (
+/obj/machinery/porta_turret/syndicate{
+	name = "old turret";
+	desc = "A rusting ballistic machinegun turret bearing the markings of the Syndicate. It isn't as potent as it once was, but can still fend off attackers with relative ease.";
+	max_integrity = 120;
+	stun_projectile = /obj/projectile/bullet/shotgun_beanbag;
+	lethal_projectile = /obj/projectile/bullet/c9mm_hp;
+	dir = 4
+	},
+/turf/closed/wall/mineral/plastitanium,
+/area/shuttle/commsagent)
+"Ca" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/shuttle/commsagent)
+"Cf" = (
+/obj/machinery/sleeper/syndie{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/shuttle/commsagent)
+"Cv" = (
+/obj/machinery/turretid{
+	req_access = list(150);
+	pixel_x = 32;
+	name = "shuttle turret control panel";
+	ailock = 1;
+	desc = "Used to control a room's automated defenses. This one has been upgraded with a special protective casing to prevent AI interfacing."
+	},
+/obj/effect/turf_decal/syndicateemblem/top/left{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/commsagent)
+"Cy" = (
+/obj/effect/turf_decal/syndicateemblem/top/right{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/commsagent)
+"CI" = (
+/obj/item/clothing/suit/space/syndicate/black/red,
+/obj/item/clothing/head/helmet/space/syndicate/black/red,
+/obj/structure/rack,
+/obj/item/clothing/mask/gas/syndicate,
+/obj/item/tank/internals/oxygen,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/commsagent)
+"CJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white,
+/area/shuttle/commsagent)
+"DW" = (
+/obj/structure/cable,
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/shuttle/commsagent)
+"DX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/closed/wall/mineral/plastitanium/explosive,
+/area/shuttle/commsagent)
+"Ef" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/south,
+/obj/structure/bed/dogbed{
+	name = "Oscar's bed";
+	desc = "It's a miracle he even sleeps in this thing."
+	},
+/mob/living/simple_animal/pet/cat/space{
+	faction = list("Syndicate");
+	name = "Oscar";
+	desc = "The only companion a Syndicate communications agent can safely travel with. An IFF chip has been mounted to their suit."
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/commsagent)
+"Em" = (
+/obj/machinery/atmospherics/components/binary/valve/on/layer3,
+/obj/effect/turf_decal/stripes,
+/turf/open/floor/engine/hull{
+	initial_gas_mix = "o2=22;n2=82;TEMP=293.15""o2=22;n2=82;TEMP=293.15"
+	},
+/area/shuttle/commsagent)
+"En" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/shuttle/commsagent)
+"Eo" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/open/floor/iron,
+/area/shuttle/commsagent)
+"EV" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/commsagent)
+"Fe" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/airalarm/syndicate/directional/north,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/commsagent)
+"Fz" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/commsagent)
+"FF" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/shuttle/commsagent)
+"Gc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/telecomms/relay/preset/ruskie,
+/turf/open/floor/iron/mil/tcomms_circuit,
+/area/shuttle/commsagent)
+"Gj" = (
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = -32
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/shuttle/commsagent)
+"Gs" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/shuttle/commsagent)
+"GD" = (
+/obj/machinery/airalarm/syndicate/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
+/turf/open/floor/iron/grimy,
+/area/shuttle/commsagent)
+"GI" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/corner,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/open/floor/iron,
+/area/shuttle/commsagent)
+"GO" = (
+/obj/machinery/door/airlock{
+	name = "Toilet"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/showroomfloor,
+/area/shuttle/commsagent)
+"GW" = (
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/shuttle/commsagent)
+"Ir" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/fancy/donut_box,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/commsagent)
+"Jg" = (
+/obj/structure/cable,
+/obj/machinery/airalarm/syndicate/directional/north,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/shuttle/commsagent)
+"Jk" = (
+/obj/machinery/computer/camera_advanced/shuttle_docker/listening_ship{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/commsagent)
+"Jp" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/shuttle/commsagent)
+"Jv" = (
+/turf/template_noop,
+/area/template_noop)
+"Kh" = (
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/external{
+	id_tag = "commsagent_bolts"
+	},
+/obj/docking_port/mobile{
+	callTime = 150;
+	dir = 2;
+	id = "commsagent";
+	movement_force = list("KNOCKDOWN"=0,"THROW"=0);
+	name = "Syndicate Listening Ship";
+	port_direction = 8;
+	preferred_direction = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/shuttle/commsagent)
+"Lz" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/shuttle/commsagent)
+"Mq" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/shuttle/commsagent)
+"Mw" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/commsagent)
+"MH" = (
+/obj/machinery/button/door{
+	id = "commsagent_bolts";
+	name = "External Airlock Bolt Controls";
+	normaldoorcontrol = 1;
+	pixel_x = -6;
+	specialfunctions = 4;
+	req_access = list(150)
+	},
+/obj/machinery/button/door{
+	id = "commsagent_windows";
+	pixel_x = 6;
+	name = "Window Shutters";
+	req_access = list(150)
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/commsagent)
+"MM" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/shuttle/commsagent)
+"Np" = (
+/obj/machinery/vending/medical/syndicate_access,
+/obj/machinery/airalarm/syndicate/directional/west,
+/turf/open/floor/iron/white,
+/area/shuttle/commsagent)
+"NK" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/shuttle/commsagent)
+"Oc" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Engine Room"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/shuttle/commsagent)
+"Os" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
+/turf/open/floor/iron,
+/area/shuttle/commsagent)
+"Ox" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/storage/box/donkpockets,
+/obj/item/storage/box/donkpockets{
+	pixel_y = 3
+	},
+/obj/machinery/airalarm/syndicate/directional/west,
+/turf/open/floor/iron,
+/area/shuttle/commsagent)
+"Pk" = (
+/obj/effect/turf_decal/syndicateemblem/bottom/right{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/commsagent)
+"Py" = (
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/shuttle/commsagent)
+"Qa" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Infirmary"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/shuttle/commsagent)
+"Qi" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/shuttle/commsagent)
+"Qk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/commsagent)
+"Qm" = (
+/obj/structure/tank_dispenser/oxygen,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/commsagent)
+"Ri" = (
+/obj/structure/table/wood,
+/obj/item/ammo_box/magazine/m9mm,
+/obj/item/ammo_box/magazine/m9mm,
+/obj/item/paper/fluff/ruins/listeningstation/briefing,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/grimy,
+/area/shuttle/commsagent)
+"Si" = (
+/obj/machinery/door/window/brigdoor/eastleft{
+	req_access = list(ACCESS_SYNDICATE);
+	name = "Self-Destruct Access"
+	},
+/obj/machinery/syndicatebomb/self_destruct,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/circuit/red/anim,
+/area/shuttle/commsagent)
+"SP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/shuttle/commsagent)
+"TE" = (
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/grimy,
+/area/shuttle/commsagent)
+"UL" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 10
+	},
+/obj/effect/turf_decal/syndicateemblem/middle/middle{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/commsagent)
+"VA" = (
+/obj/machinery/button/door{
+	id = "commsagent_bolts";
+	name = "External Airlock Bolt Controls";
+	normaldoorcontrol = 1;
+	pixel_x = -6;
+	specialfunctions = 4;
+	pixel_y = -24;
+	req_access = list(150)
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/shuttle/commsagent)
+"Wm" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/closet/secure_closet/medical1{
+	req_access = list(150)
+	},
+/turf/open/floor/iron/white,
+/area/shuttle/commsagent)
+"WD" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/syndicateemblem/bottom/middle{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/commsagent)
+"WY" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/shuttle/commsagent)
+"XB" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/commsagent)
+"XH" = (
+/obj/structure/cable,
+/obj/machinery/airalarm/syndicate/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/commsagent)
+"Yu" = (
+/obj/effect/mob_spawn/human/lavaland_syndicate/comms/space{
+	dir = 4
+	},
+/turf/open/floor/iron/grimy,
+/area/shuttle/commsagent)
+"YO" = (
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/shuttle/commsagent)
+"YP" = (
+/obj/structure/shuttle/engine/propulsion/burst{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/commsagent)
+"YX" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold/visible{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/commsagent)
+"YY" = (
+/obj/structure/cable,
+/obj/machinery/power/port_gen/pacman,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/commsagent)
+"Zb" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/commsagent)
+"Zg" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/commsagent)
+"ZM" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer1,
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/turf/open/floor/engine/hull{
+	initial_gas_mix = "o2=22;n2=82;TEMP=293.15""o2=22;n2=82;TEMP=293.15"
+	},
+/area/shuttle/commsagent)
+
+(1,1,1) = {"
+aA
+fp
+YP
+qx
+aA
+Jv
+Jv
+Jv
+aA
+fp
+YP
+qx
+aA
+"}
+(2,1,1) = {"
+aA
+vK
+vK
+vK
+aA
+Jv
+Jv
+Jv
+aA
+vK
+vK
+vK
+aA
+"}
+(3,1,1) = {"
+aA
+yx
+Ri
+Yu
+aA
+Jv
+Jv
+Jv
+aA
+Py
+Gc
+YY
+aA
+"}
+(4,1,1) = {"
+aA
+GD
+vd
+yf
+aA
+fp
+YP
+qx
+aA
+YX
+tZ
+XH
+aA
+"}
+(5,1,1) = {"
+aA
+GO
+aA
+TE
+aA
+vK
+vK
+vK
+aA
+gl
+qT
+YO
+aA
+"}
+(6,1,1) = {"
+aA
+hj
+aA
+if
+aA
+aA
+Si
+aA
+aA
+Oc
+gX
+yU
+aA
+"}
+(7,1,1) = {"
+aA
+aA
+aA
+GW
+Ox
+yX
+mC
+ir
+xv
+Gj
+aA
+aA
+aA
+"}
+(8,1,1) = {"
+Kh
+Mw
+vn
+Gs
+Jp
+Os
+Qi
+bf
+mC
+NK
+uW
+Mw
+vn
+"}
+(9,1,1) = {"
+wV
+aA
+aA
+eq
+Ca
+ql
+bo
+GI
+Mq
+VA
+aA
+aA
+wV
+"}
+(10,1,1) = {"
+Jv
+aA
+aA
+aA
+Qa
+aA
+lt
+xU
+vD
+se
+Qm
+aA
+Jv
+"}
+(11,1,1) = {"
+Jv
+Bb
+aA
+Np
+CJ
+fh
+FF
+Lz
+Fz
+CI
+aA
+Bb
+Jv
+"}
+(12,1,1) = {"
+Jv
+Jv
+aA
+Wm
+SP
+fh
+MM
+xU
+vD
+xx
+aA
+Jv
+Jv
+"}
+(13,1,1) = {"
+Jv
+Jv
+aA
+to
+kW
+fh
+WY
+Eo
+uB
+oA
+aA
+Jv
+Jv
+"}
+(14,1,1) = {"
+Jv
+Jv
+Bb
+aA
+Cf
+aA
+Jg
+xU
+nj
+aA
+Bb
+Jv
+Jv
+"}
+(15,1,1) = {"
+Jv
+Jv
+Jv
+wV
+aA
+aA
+DW
+dD
+aA
+wV
+Jv
+Jv
+Jv
+"}
+(16,1,1) = {"
+Jv
+Jv
+Jv
+ZM
+xW
+xW
+vz
+DX
+En
+Em
+Jv
+Jv
+Jv
+"}
+(17,1,1) = {"
+Jv
+Jv
+Jv
+wV
+aA
+Fe
+sA
+Ef
+aA
+wV
+Jv
+Jv
+Jv
+"}
+(18,1,1) = {"
+Jv
+Jv
+wV
+aA
+MH
+hu
+WD
+Pk
+Zb
+aA
+wV
+Jv
+Jv
+"}
+(19,1,1) = {"
+Jv
+Jv
+zk
+zU
+EV
+uz
+UL
+xT
+XB
+ay
+zk
+Jv
+Jv
+"}
+(20,1,1) = {"
+Jv
+Jv
+zk
+fK
+Qk
+Cv
+lA
+Cy
+fB
+Zg
+zk
+Jv
+Jv
+"}
+(21,1,1) = {"
+Jv
+Jv
+Bb
+aA
+Ir
+Zg
+zr
+Jk
+Zg
+aA
+Bb
+Jv
+Jv
+"}
+(22,1,1) = {"
+Jv
+Jv
+Jv
+wV
+zk
+zk
+zk
+zk
+zk
+wV
+Jv
+Jv
+Jv
+"}

--- a/_maps/shuttles/ruin_syndicate_listening_ship.dmm
+++ b/_maps/shuttles/ruin_syndicate_listening_ship.dmm
@@ -63,9 +63,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/commsagent)
-"fB" = (
-/turf/open/floor/mineral/plastitanium/red,
-/area/shuttle/commsagent)
 "fK" = (
 /obj/machinery/computer/message_monitor,
 /obj/effect/decal/cleanable/dirt,
@@ -103,7 +100,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/shuttle/commsagent)
-"hu" = (
+"hr" = (
 /obj/effect/turf_decal/syndicateemblem/bottom/left{
 	dir = 8
 	},
@@ -362,6 +359,12 @@
 /obj/item/clothing/under/syndicate/camo,
 /turf/open/floor/iron/grimy,
 /area/shuttle/commsagent)
+"yC" = (
+/obj/effect/turf_decal/syndicateemblem/top/right{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/commsagent)
 "yU" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
@@ -389,6 +392,12 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/commsagent)
+"zI" = (
+/obj/effect/turf_decal/syndicateemblem/bottom/right{
+	dir = 8
+	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/commsagent)
 "zU" = (
@@ -431,12 +440,6 @@
 	desc = "Used to control a room's automated defenses. This one has been upgraded with a special protective casing to prevent AI interfacing."
 	},
 /obj/effect/turf_decal/syndicateemblem/top/left{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/shuttle/commsagent)
-"Cy" = (
-/obj/effect/turf_decal/syndicateemblem/top/right{
 	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium/red,
@@ -597,6 +600,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/shuttle/commsagent)
+"Ha" = (
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/commsagent)
 "Ir" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/donut_box,
@@ -744,12 +750,6 @@
 /obj/machinery/airalarm/syndicate/directional/west,
 /turf/open/floor/iron,
 /area/shuttle/commsagent)
-"Pk" = (
-/obj/effect/turf_decal/syndicateemblem/bottom/right{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/shuttle/commsagent)
 "Py" = (
 /obj/machinery/firealarm/directional/north,
 /obj/machinery/atmospherics/components/unary/tank/air{
@@ -802,7 +802,7 @@
 /area/shuttle/commsagent)
 "Si" = (
 /obj/machinery/door/window/brigdoor/eastleft{
-	req_access = list(ACCESS_SYNDICATE);
+	req_access = list(150);
 	name = "Self-Destruct Access"
 	},
 /obj/machinery/syndicatebomb/self_destruct,
@@ -1230,9 +1230,9 @@ Jv
 wV
 aA
 MH
-hu
+hr
 WD
-Pk
+zI
 Zb
 aA
 wV
@@ -1262,8 +1262,8 @@ fK
 Qk
 Cv
 lA
-Cy
-fB
+yC
+Ha
 Zg
 zk
 Jv

--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -199,9 +199,8 @@
 /datum/map_template/ruin/space/listeningstation
 	id = "listeningstation"
 	suffix = "listeningstation.dmm"
-	name = "Syndicate Listening Station"
-	description = "Listening stations form the backbone of the syndicate's information-gathering operations. \
-	Assignment to these stations is dreaded by most agents, as it entails long and lonely shifts listening to nearby stations chatter incessantly about the most meaningless things."
+	name = "Syndicate Listening Vessel"
+	description = "The hangar of a Syndicate listening vessel, having just released its operator from stasis."
 
 /datum/map_template/ruin/space/old_ai_sat
 	id = "oldAIsat"

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -625,6 +625,11 @@
 	suffix = "syndicate_fighter_shiv"
 	name = "Syndicate Fighter"
 
+/datum/map_template/shuttle/ruin/syndicate_listening_ship
+	suffix = "syndicate_listening_ship"
+	name = "Syndicate Listening Ship"
+	admin_notes = "It has a ghost spawner. Please be very fucking careful with how you use this."
+
 /datum/map_template/shuttle/snowdin/mining
 	suffix = "mining"
 	name = "Snowdin Mining Elevator"

--- a/code/game/area/areas/shuttles.dm
+++ b/code/game/area/areas/shuttles.dm
@@ -204,3 +204,4 @@
 
 /area/shuttle/commsagent
 	name = "Syndicate Recon Vessel"
+	requires_power = TRUE

--- a/code/game/area/areas/shuttles.dm
+++ b/code/game/area/areas/shuttles.dm
@@ -201,3 +201,6 @@
 
 /area/shuttle/caravan/freighter3
 	name = "Tiny Freighter"
+
+/area/shuttle/commsagent
+	name = "Syndicate Recon Vessel"

--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -149,15 +149,9 @@
 	outfit = /datum/outfit/lavaland_syndicate/comms
 
 /obj/effect/mob_spawn/human/lavaland_syndicate/comms/space
-	short_desc = "You are a syndicate agent, assigned to a small listening post station situated near your hated enemy's top secret research facility: Space Station 13."
+	short_desc = "You are a syndicate agent, assigned to a small recon vessel situated near your hated enemy's top secret research facility: Space Station 13."
 	flavour_text = "Monitor enemy activity as best you can, and try to keep a low profile. Monitor enemy activity as best you can, and try to keep a low profile. Use the communication equipment to provide support to any field agents, and sow disinformation to throw Nanotrasen off your trail. Do not let the base fall into enemy hands!"
-	important_info = "DO NOT abandon the base."
-
-/obj/effect/mob_spawn/human/lavaland_syndicate/comms/space/Initialize()
-	. = ..()
-	if(prob(90)) //only has a 10% chance of existing, otherwise it'll just be a NPC syndie.
-		new /mob/living/simple_animal/hostile/syndicate/ranged(get_turf(src))
-		return INITIALIZE_HINT_QDEL
+	important_info = "DO NOT abandon ship, and DO NOT UNDER ANY CIRCUMSTANCES approach active Nanotrasen installations."
 
 /datum/outfit/lavaland_syndicate/comms
 	name = "Lavaland Syndicate Comms Agent"

--- a/code/modules/ruins/spaceruin_code/listeningstation.dm
+++ b/code/modules/ruins/spaceruin_code/listeningstation.dm
@@ -36,10 +36,10 @@
 
 /obj/item/paper/fluff/ruins/listeningstation/odd_report
 	name = "odd report"
-	info = "I wonder how much longer they will accept my empty reports. They will cancel the case soon without results. When the pickup comes, I will tell them I have lost faith in our cause, and beg them to consider a diplomatic solution. How many nuclear teams have been dispatched with those nukes? I must try and prevent more from ever being sent. If they will not listen to reason, I will detonate the warehouse myself. Maybe some day in the immediate future, space will be peaceful, though I don't intend to live to see it. And that is why I write this down- it is my sacrifice that stabilized your worlds, traveller. Spare a thought for me, and please attempt to prevent nuclear proliferation, should it ever rear its ugly head again. -DonkCo Operative #451"
+	info = "I wonder how much longer they will accept my empty reports. They will cancel the case soon without results. When the resupply comes, I will tell them I have lost faith in our cause, and beg them to consider a diplomatic solution. How many nuclear teams have been dispatched with those nukes? I must try and prevent more from ever being sent. If they will not listen to reason, I will detonate the warehouse myself. Maybe some day in the immediate future, space will be peaceful, though I don't intend to live to see it. And that is why I write this down- it is my sacrifice that stabilized your worlds, traveller. Spare a thought for me, and please attempt to prevent nuclear proliferation, should it ever rear its ugly head again. -DonkCo Operative #451"
 
 /obj/item/paper/fluff/ruins/listeningstation/briefing
 	name = "mission briefing"
-	info = "<b>Mission Details</b>: You have been assigned to a newly constructed listening post constructed within an asteroid in Nanotrasen space to monitor their plasma mining operations. Accurate intel is crucial to the success of our operatives onboard, do not fail us."
+	info = "<b>Mission Details</b>: You have been assigned to a listening vessel in Nanotrasen space to monitor their research and military operations. Accurate intel is crucial to the success of our operatives onboard, do not fail us."
 
 

--- a/code/modules/shuttle/listening_ship.dm
+++ b/code/modules/shuttle/listening_ship.dm
@@ -1,0 +1,25 @@
+/obj/machinery/computer/shuttle/listening_ship
+	name = "Syndicate Recon Vessel Helm Console"
+	desc = "Used to control the Syndicate listening ship."
+	shuttleId = "commsagent"
+	possible_destinations = "commsagent_home;whiteship_z4;commsagent_custom"
+	icon_screen = "syndishuttle"
+	icon_keyboard = "syndie_key"
+	light_color = COLOR_SOFT_RED
+	req_access = list(ACCESS_SYNDICATE)
+
+
+/obj/machinery/computer/camera_advanced/shuttle_docker/listening_ship
+	name = "Syndicate Recon Vessel Navigation Console"
+	desc = "Used to designate a precise transit location for the Syndicate listening ship."
+	shuttleId = "commsagent"
+	lock_override = NONE
+	shuttlePortId = "commsagent_custom"
+	jumpto_ports = list("commsagent_home" = 1, "whiteship_z4" = 1)
+	view_range = 10
+	x_offset = -6
+	y_offset = -10
+	designate_time = 10
+	icon_screen = "syndishuttle"
+	icon_keyboard = "syndie_key"
+	light_color = COLOR_SOFT_RED

--- a/tetrastation.dme
+++ b/tetrastation.dme
@@ -3063,6 +3063,7 @@
 #include "code\modules\shuttle\elevator.dm"
 #include "code\modules\shuttle\emergency.dm"
 #include "code\modules\shuttle\ferry.dm"
+#include "code\modules\shuttle\listening_ship.dm"
 #include "code\modules\shuttle\manipulator.dm"
 #include "code\modules\shuttle\monastery.dm"
 #include "code\modules\shuttle\navigation_computer.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

uhh


<img width="323" alt="image" src="https://github.com/TetraStation/TetraStation/assets/80979251/f385942d-a1d8-4cb2-b8e1-46a20801da62">
<img width="356" alt="image" src="https://github.com/TetraStation/TetraStation/assets/80979251/d685e9c0-04f3-4f72-bdc5-3ff18d3d1c1a">


## Why It's Good For The Game

ghostroles become cooler, comms agents are underappreciated, and also because yogstation would be a worse place to test this

## Changelog
:cl:
add: Comms agents now have a flight-capable ship that looks kind of like the Infiltrator but 10x worse
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
